### PR TITLE
Release:V0.4.2

### DIFF
--- a/meta-model/model-maven/pom.xml
+++ b/meta-model/model-maven/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.9.10</version>
+            <version>3.9.11</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -51,7 +51,7 @@
         <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
 
         <deamond.version>0.1.4.4</deamond.version>
-        <meta-open.version>0.4.0</meta-open.version>
+        <meta-open.version>0.4.1</meta-open.version>
         <autil.version>0.4.1</autil.version>
         <acanx-utils.version>0.2.2.0</acanx-utils.version>
 
@@ -617,7 +617,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.13</artifactId>
-                <version>4.0.0</version>
+                <version>4.1.0</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>


### PR DESCRIPTION
* chore(deps): bump com.acanx.meta.model:model-quote in /os-dependencies

Bumps [com.acanx.meta.model:model-quote](https://github.com/ACANX/MetaOpen) from 0.4.0 to 0.4.1.
- [Commits](https://github.com/ACANX/MetaOpen/commits)

---
updated-dependencies:
- dependency-name: com.acanx.meta.model:model-quote dependency-version: 0.4.1 dependency-type: direct:production update-type: version-update:semver-patch ...



* chore(deps): bump org.apache.maven:maven-model in /meta-model

Bumps org.apache.maven:maven-model from 3.9.10 to 3.9.11.

---
updated-dependencies:
- dependency-name: org.apache.maven:maven-model dependency-version: 3.9.11 dependency-type: direct:production update-type: version-update:semver-patch ...



* Update pom.xml

---------