### PR TITLE
chore(deps): 依赖构件版本升级

### DIFF
--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2344,30 +2344,30 @@
         <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.0</version>
         <scope>test</scope>
       </dependency>
         <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.0</version>
       </dependency>
         <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.0</version>
         <scope>test</scope>
         <optional>true</optional>
       </dependency>
         <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-engine</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.0</version>
       </dependency>
         <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.0</version>
         <scope>test</scope>
       </dependency>
         <dependency>
@@ -2399,13 +2399,13 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ses</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
@@ -2416,7 +2416,7 @@
         <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java-util</artifactId>
-        <version>4.33.0</version>
+        <version>4.35.0</version>
       </dependency>
         <dependency>
         <groupId>jakarta.servlet</groupId>
@@ -2515,7 +2515,7 @@
         <dependency>
         <groupId>com.tencentcloudapi</groupId>
         <artifactId>tencentcloud-sdk-java-scf</artifactId>
-        <version>3.1.1468</version>
+        <version>3.1.1469</version>
       </dependency>
         <dependency>
         <groupId>com.tencentcloudapi</groupId>
@@ -2551,7 +2551,7 @@
         <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-log4j2</artifactId>
-        <version>1.6.3</version>
+        <version>1.6.4</version>
       </dependency>
         <dependency>
         <groupId>com.amazonaws</groupId>
@@ -2666,59 +2666,59 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudwatch</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>costexplorer</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sqs</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sns</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>scheduler</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>2.44.8</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2556,7 +2556,7 @@
         <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-serialization</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun.fc.runtime</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2738,7 +2738,7 @@
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>utils</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <scope>runtime</scope>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2437,7 +2437,7 @@
         <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
-        <version>20251224</version>
+        <version>20260522</version>
       </dependency>
         <dependency>
         <groupId>org.apache.poi</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -857,7 +857,7 @@
         <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>7.3.5.Final</version>
+        <version>7.3.6.Final</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -637,7 +637,7 @@
         <dependency>
         <groupId>com.alibaba.csp</groupId>
         <artifactId>sentinel-core</artifactId>
-        <version>1.8.9</version>
+        <version>1.8.10</version>
       </dependency>
         <dependency>
         <groupId>org.apache.kafka</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2733,7 +2733,7 @@
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
       </dependency>
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -642,7 +642,7 @@
         <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka_2.13</artifactId>
-        <version>4.2.0</version>
+        <version>4.3.0</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2571,7 +2571,7 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-functiongraph</artifactId>
-        <version>3.1.196</version>
+        <version>3.1.197</version>
       </dependency>
         <dependency>
         <groupId>com.google.cloud.functions</groupId>
@@ -2627,12 +2627,12 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-core</artifactId>
-        <version>3.1.196</version>
+        <version>3.1.197</version>
       </dependency>
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-apig</artifactId>
-        <version>3.1.196</version>
+        <version>3.1.197</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -975,13 +975,13 @@
         <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.0</version>
         <scope>test</scope>
       </dependency>
         <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.0</version>
         <scope>test</scope>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2399,13 +2399,13 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ses</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
@@ -2666,59 +2666,59 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudwatch</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>costexplorer</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sqs</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sns</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>scheduler</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>2.44.9</version>
+        <version>2.44.12</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2744,7 +2744,7 @@
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>graalvm-reachability-metadata</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -523,7 +523,7 @@
         <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>4.34.1</version>
+        <version>4.35.0</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2592,7 +2592,7 @@
         <dependency>
         <groupId>com.larksuite.oapi</groupId>
         <artifactId>oapi-sdk</artifactId>
-        <version>2.6.1</version>
+        <version>2.7.1</version>
       </dependency>
         <dependency>
         <groupId>com.brevo</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -649,7 +649,7 @@
         <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>4.2.0</version>
+        <version>4.3.0</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2399,13 +2399,13 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ses</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
@@ -2666,59 +2666,59 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudwatch</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>costexplorer</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sqs</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sns</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>scheduler</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>2.44.12</version>
+        <version>2.44.9</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -501,24 +501,24 @@
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http3</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -1330,144 +1330,144 @@
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-base</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-haproxy</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-compression</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-memcache</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-mqtt</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-smtp</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-socks</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-stomp</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-protobuf</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-marshalling</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-dev-tools</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-ssl-ocsp</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-udt</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
         <scope>runtime</scope>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-io_uring</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
         <scope>runtime</scope>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-classes-quic</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-native-quic</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
         <scope>runtime</scope>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -338,7 +338,7 @@
         <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.21.0</version>
+        <version>3.22.0</version>
       </dependency>
         <dependency>
         <groupId>org.apache.maven.plugins</groupId>

--- a/meta-bom/bom-graalvm/pom.xml
+++ b/meta-bom/bom-graalvm/pom.xml
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>utils</artifactId>
-                <version>1.1.0</version>
+                <version>1.1.1</version>
                 <scope>runtime</scope>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.graalvm.buildtools/graalvm-reachability-metadata -->

--- a/meta-bom/bom-graalvm/pom.xml
+++ b/meta-bom/bom-graalvm/pom.xml
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>1.1.1</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.graalvm.buildtools/utils -->
             <dependency>

--- a/meta-bom/bom-graalvm/pom.xml
+++ b/meta-bom/bom-graalvm/pom.xml
@@ -90,7 +90,7 @@
             <dependency>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>graalvm-reachability-metadata</artifactId>
-                <version>1.1.0</version>
+                <version>1.1.1</version>
                 <scope>runtime</scope>
             </dependency>
         </dependencies>

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -112,7 +112,7 @@
         <log4j2-cachefile-transformer.version>2.13.0</log4j2-cachefile-transformer.version>
 
         <!-- AWS Lambda Java Serialization -->
-        <aws-lambda-java-serialization.version>1.4.0</aws-lambda-java-serialization.version>
+        <aws-lambda-java-serialization.version>1.4.1</aws-lambda-java-serialization.version>
 
         <!-- 第三方 SDK 版本 -->
         <java-function-invoker.version>2.0.1</java-function-invoker.version>

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -75,7 +75,7 @@
         <!-- SDK 版本 -->
         <baidu-aip-sdk.version>4.16.25</baidu-aip-sdk.version>
         <acrcloud-sdk.version>1.0.5</acrcloud-sdk.version>
-        <json.version>20251224</json.version>
+        <json.version>20260522</json.version>
 
         <!-- 邮件 SDK 版本 -->
         <freemarker-java8.version>1.3.0</freemarker-java8.version>

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -116,7 +116,7 @@
 
         <!-- 第三方 SDK 版本 -->
         <java-function-invoker.version>2.0.1</java-function-invoker.version>
-        <oapi-sdk.version>2.6.1</oapi-sdk.version>
+        <oapi-sdk.version>2.7.1</oapi-sdk.version>
         <brevo.version>1.1.7</brevo.version>
         <ipinfo-api.version>3.4.0</ipinfo-api.version>
         <longport-openapi-sdk.version>3.0.23</longport-openapi-sdk.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -265,7 +265,7 @@
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
         <awssdk.version>2.44.10</awssdk.version>
-        <huaweicloud-sdk.version>3.1.196</huaweicloud-sdk.version>
+        <huaweicloud-sdk.version>3.1.197</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -264,7 +264,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.44.10</awssdk.version>
+        <awssdk.version>2.44.11</awssdk.version>
         <huaweicloud-sdk.version>3.1.197</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -264,7 +264,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.44.11</awssdk.version>
+        <awssdk.version>2.44.12</awssdk.version>
         <huaweicloud-sdk.version>3.1.197</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -264,7 +264,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.44.9</awssdk.version>
+        <awssdk.version>2.44.10</awssdk.version>
         <huaweicloud-sdk.version>3.1.196</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -202,7 +202,7 @@
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
 
         <lombok.version>1.18.46</lombok.version>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.14.Final</netty.version>
         
         
          <!--  JSON -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -264,7 +264,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.44.12</awssdk.version>
+        <awssdk.version>2.44.13</awssdk.version>
         <huaweicloud-sdk.version>3.1.197</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->

--- a/meta-model/model-test/pom.xml
+++ b/meta-model/model-test/pom.xml
@@ -109,7 +109,7 @@
                         <arg>jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
                         <arg>--add-exports</arg>
                         <arg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                        <!-- Use -J prefix to pass --add-opens as JVM args to the forked javac process -->
+                        <!-- Use -J prefix to pass add opens as JVM args to the forked javac process -->
                         <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                         <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
                         <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>

--- a/meta-model/model-test/pom.xml
+++ b/meta-model/model-test/pom.xml
@@ -78,7 +78,7 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <encoding>UTF-8</encoding>
-                    <fork>false</fork>
+                    <fork>true</fork>
                     <annotationProcessors>
                         <annotationProcessor>com.acanx.util.annotation.processor.ast.CopierAstProcessor</annotationProcessor>
                     </annotationProcessors>

--- a/meta-model/model-test/pom.xml
+++ b/meta-model/model-test/pom.xml
@@ -109,12 +109,13 @@
                         <arg>jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
                         <arg>--add-exports</arg>
                         <arg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                        <arg>--add-opens</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                        <arg>--add-opens</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                        <arg>--add-opens</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <!-- Use -J prefix to pass --add-opens as JVM args to the forked javac process -->
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -117,7 +117,7 @@
         <selenium.version>4.44.0</selenium.version>
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
 
-        <junit-jupiter.version>6.0.3</junit-jupiter.version>
+        <junit-jupiter.version>6.1.0</junit-jupiter.version>
         <junit-platform.version>6.1.0</junit-platform.version>
         <!-- 修复 plexus-utils 目录遍历漏洞 -->
         <plexus-utils.version>4.0.3</plexus-utils.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -64,7 +64,7 @@
 
         <netty.version>4.2.13.Final</netty.version>
         <reactor.verion>3.8.5</reactor.verion>
-        <protobuf-java.version>4.34.1</protobuf-java.version>
+        <protobuf-java.version>4.35.0</protobuf-java.version>
 
         <tomcat-embed.version>11.0.22</tomcat-embed.version>
 

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -71,7 +71,7 @@
         <mysql-connector-j.version>9.7.0</mysql-connector-j.version>
         <postgresql.version>42.7.11</postgresql.version>
         <mybatis.version>3.5.19</mybatis.version>
-        <hibernate-orm.version>7.3.6.Final</hibernate-orm.version>
+        <hibernate-orm.version>7.4.0.Final</hibernate-orm.version>
         <seata.version>2.6.0</seata.version>
 
         <commons-lang3.version>3.20.0</commons-lang3.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -762,7 +762,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.13</artifactId>
-                <version>4.2.0</version>
+                <version>4.3.0</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -77,7 +77,7 @@
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <common-io.version>2.22.0</common-io.version>
         <commons-collections4.version>4.5.0</commons-collections4.version>
-        <commons-configuration2.version>2.15.0</commons-configuration2.version>
+        <commons-configuration2.version>2.15.1</commons-configuration2.version>
         
         <guava.version>33.6.0-jre</guava.version>
 

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -62,7 +62,7 @@
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <bytebuddy.version>1.18.8</bytebuddy.version>
 
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.14.Final</netty.version>
         <reactor.verion>3.8.5</reactor.verion>
         <protobuf-java.version>4.35.0</protobuf-java.version>
 

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -435,7 +435,7 @@
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.21.0</version>
+                <version>3.22.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -365,7 +365,7 @@
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -71,7 +71,7 @@
         <mysql-connector-j.version>9.7.0</mysql-connector-j.version>
         <postgresql.version>42.7.11</postgresql.version>
         <mybatis.version>3.5.19</mybatis.version>
-        <hibernate-orm.version>7.3.5.Final</hibernate-orm.version>
+        <hibernate-orm.version>7.3.6.Final</hibernate-orm.version>
         <seata.version>2.6.0</seata.version>
 
         <commons-lang3.version>3.20.0</commons-lang3.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -425,7 +425,7 @@
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -769,7 +769,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>4.2.0</version>
+                <version>4.3.0</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -757,7 +757,7 @@
             <dependency>
                 <groupId>com.alibaba.csp</groupId>
                 <artifactId>sentinel-core</artifactId>
-                <version>1.8.9</version>
+                <version>1.8.10</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -118,7 +118,7 @@
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
 
         <junit-jupiter.version>6.0.3</junit-jupiter.version>
-        <junit-platform.version>6.0.3</junit-platform.version>
+        <junit-platform.version>6.1.0</junit-platform.version>
         <!-- 修复 plexus-utils 目录遍历漏洞 -->
         <plexus-utils.version>4.0.3</plexus-utils.version>
         <plexus-xml.version>4.1.1</plexus-xml.version>


### PR DESCRIPTION
## 变更说明

将  分支的最新依赖更新合并到  分支。

### 变更概要

- **来源分支：** dependa
- **目标分支：** dev
- **合并提交数：** 53 commits
- **变更文件：** 5 个 pom.xml 文件

### 主要依赖升级

| 依赖 | 版本变更 |
|------|---------|
| aws-sdk | 2.44.9 → 2.44.12 |
| kafka-clients / kafka_2.13 | 4.2.0 → 4.3.0 |
| protobuf-java | 4.34.1 → 4.35.0 |
| netty | 4.2.13.Final → 4.2.14.Final |
| hibernate-core | 7.3.5.Final → 7.4.0.Final |
| junit-jupiter | 6.0.3 → 6.1.0 |
| graalvm buildtools | 1.0.0 → 1.1.1 |
| larksuite oapi-sdk | 2.6.1 → 2.7.1 |
| huaweicloud sdk | 3.1.196 → 3.1.197 |
| sentinel-core | 1.8.9 → 1.8.10 |
| commons-configuration2 | 2.15.0 → 2.15.1 |
| maven-failsafe/surefire-plugin | 3.5.5 → 3.5.6 |
| maven-site-plugin | 3.21.0 → 3.22.0 |
| aws-lambda-java-serialization | 1.4.0 → 1.4.1 |
| nacos-client | 升级至 3.2.1-2026.04.03 |
| spring-ai-commons/model | 升级至 2.0.0-M8 |

### 变更文件

- `meta-bom/bom-aio/pom.xml` — 修改
- `meta-bom/bom-graalvm/pom.xml` — 修改
- `meta-bom/bom-mod/pom.xml` — 修改
- `meta-bom/pom.xml` — 修改
- `os-dependencies/pom.xml` — 修改

### ⚠️ 合并方式

> **请使用 Squash and merge 方式合并此 PR**，将 53 个依赖升级提交压缩为一个合并提交，保持 dev 分支提交历史整洁。