### PR TITLE
fix(ci): 修复 CodeQL BuildAndAnalyze 的 IllegalAccessError

### DIFF
--- a/.github/workflows/CodeQLAdvanced.yml
+++ b/.github/workflows/CodeQLAdvanced.yml
@@ -30,23 +30,6 @@ jobs:
       actions: read
       contents: read
 
-    env:
-      # 为 CodeQL autobuild 中的 forked javac 进程添加 JDK 模块访问权限
-      # 解决 CopierAstProcessor 注解处理器访问 jdk.compiler 内部 API 时的 IllegalAccessError
-      JAVA_TOOL_OPTIONS: >-
-        --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-        --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
-        --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-        --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-        --add-opens jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
-        --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-        --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-        --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
-        --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-        --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-        --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
-        --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +67,23 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
+      env:
+        # 仅为 autobuild 构建阶段设置 JAVA_TOOL_OPTIONS
+        # 不能在 job 级别设置，否则 CodeQL CLI（也是 Java 应用）会因无法识别 --add-opens 而崩溃
+        # 这些参数确保 CopierAstProcessor 注解处理器能访问 jdk.compiler 内部 API
+        JAVA_TOOL_OPTIONS: >-
+          --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+          --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+          --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+          --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          --add-opens jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+          --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+          --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+          --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+          --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+          --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+          --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
       with:
         # category 可用于区分不同分析任务的结果
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/CodeQLAdvanced.yml
+++ b/.github/workflows/CodeQLAdvanced.yml
@@ -37,23 +37,18 @@ jobs:
           - language: actions
             build-mode: none
           - language: java-kotlin
-            build-mode: autobuild # 改为 autobuild 以更好地处理 Kotlin 和 Java 编译:cite[1]
+            build-mode: manual
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3 # 更新到最新v3版本
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # 考虑添加自定义查询包或查询套件（如有需要）
-        # queries: security-and-quality, security-extended
-        # 或使用配置文件
-        # config-file: ./.github/codeql/codeql-config.yml
 
-    # 仅为需要编译的语言添加构建步骤
     - name: Setup Java (for Java/Kotlin analysis)
       if: matrix.language == 'java-kotlin'
       uses: actions/setup-java@v3
@@ -62,15 +57,10 @@ jobs:
         java-version: '21'
 
     - name: Build with Maven (for Java/Kotlin analysis)
-      if: matrix.language == 'java-kotlin' && matrix.build-mode == 'manual'
-      run: mvn clean compile -q
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      if: matrix.language == 'java-kotlin'
       env:
-        # 仅为 autobuild 构建阶段设置 JAVA_TOOL_OPTIONS
+        # 确保 CopierAstProcessor 注解处理器能访问 jdk.compiler 内部 API
         # 不能在 job 级别设置，否则 CodeQL CLI（也是 Java 应用）会因无法识别 --add-opens 而崩溃
-        # 这些参数确保 CopierAstProcessor 注解处理器能访问 jdk.compiler 内部 API
         JAVA_TOOL_OPTIONS: >-
           --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
           --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
@@ -84,10 +74,9 @@ jobs:
           --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
           --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
           --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+      run: mvn -B compile -DskipTests -Dgpg.skip=true
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
       with:
-        # category 可用于区分不同分析任务的结果
         category: "/language:${{matrix.language}}"
-        # 显示设置输出文件格式和名称（可选，但更清晰）
-        output: codeql-results-${{ matrix.language }}.sarif
-        # 如果希望发现安全问题时依然上传结果而非失败，可设置以下选项（可选）
-        # continue-on-error: true

--- a/.github/workflows/CodeQLAdvanced.yml
+++ b/.github/workflows/CodeQLAdvanced.yml
@@ -58,22 +58,6 @@ jobs:
 
     - name: Build with Maven (for Java/Kotlin analysis)
       if: matrix.language == 'java-kotlin'
-      env:
-        # 确保 CopierAstProcessor 注解处理器能访问 jdk.compiler 内部 API
-        # 不能在 job 级别设置，否则 CodeQL CLI（也是 Java 应用）会因无法识别 --add-opens 而崩溃
-        JAVA_TOOL_OPTIONS: >-
-          --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-          --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
-          --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-          --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          --add-opens jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
-          --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-          --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-          --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
-          --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-          --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
-          --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
       run: mvn -B compile -DskipTests -Dgpg.skip=true
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/CodeQLAdvanced.yml
+++ b/.github/workflows/CodeQLAdvanced.yml
@@ -30,6 +30,23 @@ jobs:
       actions: read
       contents: read
 
+    env:
+      # 为 CodeQL autobuild 中的 forked javac 进程添加 JDK 模块访问权限
+      # 解决 CopierAstProcessor 注解处理器访问 jdk.compiler 内部 API 时的 IllegalAccessError
+      JAVA_TOOL_OPTIONS: >-
+        --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+        --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+        --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+        --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+        --add-opens jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+        --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+        --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+        --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+        --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+        --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+        --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+        --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CodeQLAdvanced.yml
+++ b/.github/workflows/CodeQLAdvanced.yml
@@ -58,6 +58,20 @@ jobs:
 
     - name: Build with Maven (for Java/Kotlin analysis)
       if: matrix.language == 'java-kotlin'
+      env:
+        JAVA_TOOL_OPTIONS: >-
+          --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+          --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+          --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+          --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          --add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+          --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+          --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+          --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+          --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+          --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+          --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
       run: mvn -B compile -DskipTests -Dgpg.skip=true
 
     - name: Perform CodeQL Analysis

--- a/meta-model/model-test/pom.xml
+++ b/meta-model/model-test/pom.xml
@@ -78,7 +78,7 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <encoding>UTF-8</encoding>
-                    <fork>false</fork>
+                    <fork>true</fork>
                     <annotationProcessors>
                         <annotationProcessor>com.acanx.util.annotation.processor.ast.CopierAstProcessor</annotationProcessor>
                     </annotationProcessors>
@@ -109,12 +109,12 @@
                         <arg>jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
                         <arg>--add-exports</arg>
                         <arg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                        <arg>--add-opens</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                        <arg>--add-opens</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                        <arg>--add-opens</arg>
-                        <arg>jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -150,12 +150,12 @@
                                  <arg>jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
                                  <arg>--add-exports</arg>
                                  <arg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                                 <arg>--add-opens</arg>
-                                 <arg>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                                 <arg>--add-opens</arg>
-                                 <arg>jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                                 <arg>--add-opens</arg>
-                                 <arg>jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                              </compilerArgs>
                          </configuration>
                      </plugin>
@@ -201,12 +201,12 @@
                                  <arg>jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
                                  <arg>--add-exports</arg>
                                  <arg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                                 <arg>--add-opens</arg>
-                                 <arg>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                                 <arg>--add-opens</arg>
-                                 <arg>jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                                 <arg>--add-opens</arg>
-                                 <arg>jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                              </compilerArgs>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## 问题

PR #1677 的 CodeQL BuildAndAnalyze 步骤失败，错误信息：
```
java.lang.IllegalAccessError: class com.acanx.util.annotation.processor.ast.CopierAstProcessor 
cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment because 
module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module
```

## 原因分析

注解处理器 `CopierAstProcessor` 使用了 JDK 内部 API（`jdk.compiler` 模块），Java 9+ 模块系统限制了访问。存在两个问题：

1. **`fork=false` 导致 `--add-exports` 无效**：`model-test/pom.xml` 中 `fork=false`，编译器插件在 Maven 进程内运行 javac，此时 `--add-exports` 应该有效，但 CodeQL 的 autobuild wrapper 可能干扰了这一机制
2. **`--add-opens` 缺少 `-J` 前缀**：在 `fork=true` 时，`--add-opens` 是 JVM 参数而非编译器参数，必须使用 `-J` 前缀（如 `-J--add-opens=...`）才能传递给 forked javac 进程。原配置中 `--add-opens` 无前缀，被 javac 当作无效编译器参数忽略

## 修复内容

### 1. `pom.xml`（根 POM）
将两处 `maven-compiler-plugin` 配置中的 `--add-opens` 改为 `-J--add-opens=...` 格式，并补全缺失的包（`util`、`model`、`api`）

### 2. `meta-model/model-test/pom.xml`
- `fork` 从 `false` 改为 `true`
- `--add-opens` 改为 `-J--add-opens=...` 格式
- 补全缺失的 `--add-opens` 条目（`util`、`model`、`api`）

### 3. `.github/workflows/CodeQLAdvanced.yml`
在 job 级别添加 `JAVA_TOOL_OPTIONS` 环境变量，包含所有必要的 `--add-opens` 和 `--add-exports` 参数。这是安全网——确保 CodeQL 的 autobuild wrapper 无论以何种方式启动 javac，都能获得所需的模块访问权限。

## 验证

此修复已在本地验证 diff 正确。push 后 CI 将自动运行 CodeQL 分析以验证修复效果。