### PR TITLE
fix(ci): SonarQube.yml 补充 sonar.organization 和 sonar.host.url 参数

### DIFF
--- a/.github/workflows/SonarQube.yml
+++ b/.github/workflows/SonarQube.yml
@@ -39,4 +39,4 @@ jobs:
       - name: BuildAndAnalyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ACANX_MetaOpen -Dgpg.skip=true 
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ACANX_MetaOpen -Dsonar.organization=acanx -Dsonar.host.url=https://sonarcloud.io -Dgpg.skip=true 


### PR DESCRIPTION
## 修复内容

SonarQube CI 的  命令缺少必要参数，导致 CI 报 "Project not found" 错误。

**修改文件：** 

**变更：**
```diff
- run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ACANX_MetaOpen -Dgpg.skip=true
+ run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ACANX_MetaOpen -Dsonar.organization=acanx -Dsonar.host.url=https://sonarcloud.io -Dgpg.skip=true
```

补充了两个缺失的参数：
- `-Dsonar.organization=acanx`
- `-Dsonar.host.url=https://sonarcloud.io`