### PR TITLE
fix(ci): make 'in...' part optional in Dependabot PR title regex

### DIFF
--- a/.github/workflows/RenameDependabotBumpPRTitle.yml
+++ b/.github/workflows/RenameDependabotBumpPRTitle.yml
@@ -31,7 +31,7 @@ jobs:
             const prNum = context.payload.pull_request.number;
             // 抽取包名和新版本
             const matched = context.payload.pull_request.title.match(
-              /bump\s+(.+)\s+from\s+(.+)\s+to\s+(.+)\s+in(.+)/
+              /bump\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)(?:\s+in(.+))?$/
             );
             if (!matched) return;
             const [, pkg, oldVer, newVer, pomFile] = matched;


### PR DESCRIPTION
## 问题

Dependabot PR 标题重命名的 GitHub Actions 工作流中，正则表达式要求标题必须以 `in...` 结尾，导致没有子目录路径的 PR 标题无法匹配。

例如：
- ✅ `bump com.foo:bar from 1.0 to 2.0 in /path/to/dir` — 旧正则可以匹配
- ❌ `bump com.foo:bar from 1.0 to 2.0` — 旧正则无法匹配

## 修复

将 `in(...)` 部分改为可选，同时使用非贪婪匹配和行尾锚点：

**旧正则：**
```javascript
/bump\s+(.+)\s+from\s+(.+)\s+to\s+(.+)\s+in(.+)/
```

**新正则：**
```javascript
/bump\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)(?:\s+in(.+))?$/
```

### 变更说明

1. `(.+)` → `(.+?)` — 非贪婪匹配，避免过度捕获
2. `\s+in(.+)` → `(?:\s+in(.+))?` — `in...` 部分变为可选
3. 添加 `$` 锚点 — 确保匹配到行尾

## 测试

| PR 标题 | 匹配结果 |
|---------|---------|
| `bump com.foo:bar from 1.0 to 2.0 in /some/path` | ✅ pkg=`com.foo:bar`, old=`1.0`, new=`2.0` |
| `bump com.foo:bar from 1.0 to 2.0` | ✅ pkg=`com.foo:bar`, old=`1.0`, new=`2.0` |