### PR TITLE
fix(ci): make 'in...' part optional in Dependabot PR title regex

### DIFF
--- a/.github/workflows/RenameDependabotBumpPRTitle.yml
+++ b/.github/workflows/RenameDependabotBumpPRTitle.yml
@@ -31,7 +31,7 @@ jobs:
             const prNum = context.payload.pull_request.number;
             // 抽取包名和新版本
             const matched = context.payload.pull_request.title.match(
-              /bump\s+(.+)\s+from\s+(.+)\s+to\s+(.+)\s+in(.+)/
+              /bump\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)(?:\s+in(.+))?$/
             );
             if (!matched) return;
             const [, pkg, oldVer, newVer, pomFile] = matched;


### PR DESCRIPTION
## 修复 Dependabot PR 标题重命名正则表达式

### 问题描述
`RenameDependabotBumpPRTitle` workflow 中的正则表达式要求 PR 标题末尾必须有 `in...` 部分，但 Dependabot 生成的一些标题没有这个部分，导致重命名失败。

### 修复内容
修改 `.github/workflows/RenameDependabotBumpPRTitle.yml` 中的正则表达式：
- **旧正则：** `/bump\s+(.+)\s+from\s+(.+)\s+to\s+(.+)\s+in(.+)/`
- **新正则：** `/bump\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)(?:\s+in(.+))?$/`

### 测试用例
| 输入标题 | 匹配结果 |
|---------|---------|
| `bump logback.version from 1.5.32 to 1.5.33` | ✅ 匹配 (无 in) |
| `bump org.apache.commons-commons-configuration2 from 2.15.0 to 2.15.1 in pom.xml` | ✅ 匹配 (有 in) |
| `bump com.larksuite.oapi:oapi-sdk from 2.7.1 to 2.7.2` | ✅ 匹配 (无 in) |

### 验证步骤
1. 合并此 PR 到 test 分支
2. 触发一个新的 Dependabot PR（如有）
3. 检查 RenameDependabotBumpPRTitle workflow 是否正确重命名 PR 标题
4. 验证通过后，再合并到 dev 分支