### PR TITLE
fix(ci): 修复 Dependabot PR 标题重命名正则表达式

### DIFF
--- a/.github/workflows/RenameDependabotBumpPRTitle.yml
+++ b/.github/workflows/RenameDependabotBumpPRTitle.yml
@@ -31,7 +31,7 @@ jobs:
             const prNum = context.payload.pull_request.number;
             // 抽取包名和新版本
             const matched = context.payload.pull_request.title.match(
-              /bump\s+(.+)\s+from\s+(.+)\s+to\s+(.+)\s+in(.+)/
+              /bump\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)(?:\s+in(.+))?$/
             );
             if (!matched) return;
             const [, pkg, oldVer, newVer, pomFile] = matched;


### PR DESCRIPTION
## 目标分支

feat/rename-dependabot-title（特性分支）

## 问题

RenameDependabotBumpPRTitle 工作流中的正则表达式要求 PR 标题包含 `in <file>` 后缀，但 Dependabot 有时不生成该部分。

## 修复

将正则从：
```
/bump\s+(.+)\s+from\s+(.+)\s+to\s+(.+)\s+in(.+)/
```

改为：
```
/bump\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)(?:\s+in(.+))?$/```

使 `in <file>` 部分可选，兼容两种标题格式。