### PR TITLE
fix: use non-greedy regex for dependabot PR title parsing

### DIFF
--- a/.github/workflows/RenameDependabotBumpPRTitle.yml
+++ b/.github/workflows/RenameDependabotBumpPRTitle.yml
@@ -31,7 +31,7 @@ jobs:
             const prNum = context.payload.pull_request.number;
             // 抽取包名和新版本
             const matched = context.payload.pull_request.title.match(
-              /bump\s+(.+)\s+from\s+(.+)\s+to\s+(.+)\s+in(.+)/
+              /bump\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)(?:\s+in(.+))?$/
             );
             if (!matched) return;
             const [, pkg, oldVer, newVer, pomFile] = matched;


### PR DESCRIPTION
## 修复内容

修改 `.github/workflows/RenameDependabotBumpPRTitle.yml` 中的正则表达式：

**修改前：**
```
/bump\s+(.+)\s+from\s+(.+)\s+to\s+(.+)\s+in(.+)/
```

**修改后：**
```
/bump\s+(.+?)\s+from\s+(.+?)\s+to\s+(.+?)(?:\s+in(.+))?$/
```

### 改动说明
1. `(.+)` → `(.+?)` — 使用非贪婪匹配，避免多个依赖名时匹配越界
2. `(?:\s+in(.+))?` — 使 `in` 部分变为可选，兼容不带路径的 PR 标题
3. 添加 `$` 锚点 — 确保匹配到字符串末尾