### PR TITLE
fix: 修复 SonarCloud 重复字符串字面量问题（S1192）

### DIFF
--- a/meta-model/model-dingtalk/src/main/java/com/acanx/meta/util/DingTalkSignUtil.java
+++ b/meta-model/model-dingtalk/src/main/java/com/acanx/meta/util/DingTalkSignUtil.java
@@ -10,6 +10,8 @@ import java.util.Base64;
  */
 public class DingTalkSignUtil {
 
+    private static final String UTF8 = "UTF-8";
+
     /**
      *
      * @param secret      私钥
@@ -20,9 +22,9 @@ public class DingTalkSignUtil {
     public static String generateSign(String secret, Long timestamp) throws Exception {
         String stringToSign = timestamp + "\n" + secret;
         Mac mac = Mac.getInstance("HmacSHA256");
-        mac.init(new SecretKeySpec(secret.getBytes("UTF-8"), "HmacSHA256"));
-        byte[] signData = mac.doFinal(stringToSign.getBytes("UTF-8"));
-        String sign = URLEncoder.encode(Base64.getEncoder().encodeToString(signData), "UTF-8");
+        mac.init(new SecretKeySpec(secret.getBytes(UTF8), "HmacSHA256"));
+        byte[] signData = mac.doFinal(stringToSign.getBytes(UTF8));
+        String sign = URLEncoder.encode(Base64.getEncoder().encodeToString(signData), UTF8);
         return sign;
     }
 

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
@@ -27,6 +27,8 @@ import java.io.IOException;
  */
 public class ArtifactService {
 
+    private static final String UNKNOWN = "UNKNOWN";
+
 
     /**
      *
@@ -57,8 +59,8 @@ public class ArtifactService {
             ma.setOriginDataProvider("metadata.xml");
         } else {
             // ma.setIgnoreFlag(Boolean.TRUE);
-            ma.setType("UNKNOWN");
-            ma.setPackaging("UNKNOWN");
+            ma.setType(UNKNOWN);
+            ma.setPackaging(UNKNOWN);
         }
         return ma;
     }
@@ -105,8 +107,8 @@ public class ArtifactService {
             ma.setPackaging(packagingType);
             ma.setOriginDataProvider("pom.xml");
         } else {
-            ma.setType("UNKNOWN");
-            ma.setPackaging("UNKNOWN");
+            ma.setType(UNKNOWN);
+            ma.setPackaging(UNKNOWN);
         }
         return ma;
     }


### PR DESCRIPTION
## 修复内容

将重复的字符串字面量提取为 static final 常量。

修复 SonarCloud HIGH 级别问题 2 个（java:S1192）。

Closes #1706

## 修改文件

| 文件 | 修改 |
|------|------|
| ArtifactService.java | "UNKNOWN" 提取为常量（4处） |
| DingTalkSignUtil.java | "UTF-8" 提取为常量（3处） |