### PR TITLE
fix: LOW + INFO 级别代码质量问题修复

### DIFF
--- a/meta-model/model-deepseek/src/main/java/com/acanx/meta/model/deepseek/ri/DeepSeekRi.java
+++ b/meta-model/model-deepseek/src/main/java/com/acanx/meta/model/deepseek/ri/DeepSeekRi.java
@@ -9,11 +9,11 @@ public class DeepSeekRi {
 
     private String model;
     private Boolean stream;
-    public double temperature;
+    private double temperature;
     /**
      *  max_tokens  模型单次回答的最大长度（含思维连输出）
      */
-    public int maxTokens;
+    private int maxTokens;
     private List<Message> messages = new ArrayList<>();
 
     public DeepSeekRi(String model, Boolean stream, List<Message> messages) {
@@ -22,7 +22,7 @@ public class DeepSeekRi {
         this.messages = messages;
     }
 
-    public DeepSeekRi(String model, Boolean stream, double temperature, int max_tokens, List<Message> messages) {
+    public DeepSeekRi(String model, Boolean stream, double temperature, int maxTokens, List<Message> messages) {
         this.model = model;
         this.stream = stream;
         this.temperature = temperature;

--- a/meta-model/model-deepseek/src/test/java/com/acanx/meta/model/deepseek/AppTest.java
+++ b/meta-model/model-deepseek/src/test/java/com/acanx/meta/model/deepseek/AppTest.java
@@ -13,7 +13,7 @@ public class AppTest {
      * Rigorous Test :-)
      */
     @Test
-    public void shouldAnswerWithTrue() {
+    void shouldAnswerWithTrue() {
         Assertions.assertTrue(true);
     }
 

--- a/meta-model/model-dingtalk/src/test/java/com/acanx/meta/model/dingtalk/AppTest.java
+++ b/meta-model/model-dingtalk/src/test/java/com/acanx/meta/model/dingtalk/AppTest.java
@@ -13,7 +13,7 @@
 //     * Rigorous Test :-)
 //     */
 //    @Test
-//    public void shouldAnswerWithTrue() {
+//    void shouldAnswerWithTrue() {
 //        Assertions.assertTrue(true);
 //    }
 //

--- a/meta-model/model-folo/src/test/java/com/acanx/meta/model/AppTest.java
+++ b/meta-model/model-folo/src/test/java/com/acanx/meta/model/AppTest.java
@@ -13,7 +13,7 @@ public class AppTest {
      * Rigorous Test :-)
      */
     @Test
-    public void shouldAnswerWithTrue() {
+    void shouldAnswerWithTrue() {
         Assertions.assertTrue(true);
     }
 

--- a/meta-model/model-maven/src/test/java/com/acanx/meta/model/maven/AppTest.java
+++ b/meta-model/model-maven/src/test/java/com/acanx/meta/model/maven/AppTest.java
@@ -13,7 +13,7 @@ public class AppTest {
      * Rigorous Test :-)
      */
     @Test
-    public void shouldAnswerWithTrue() {
+    void shouldAnswerWithTrue() {
         Assertions.assertTrue(true);
     }
 

--- a/meta-model/model-quote/src/test/java/com/acanx/meta/model/quote/AppTest.java
+++ b/meta-model/model-quote/src/test/java/com/acanx/meta/model/quote/AppTest.java
@@ -1,3 +1,5 @@
+package com.acanx.meta.model.quote.AppTest.java;
+
 //package com.acanx.meta.model;
 //
 //
@@ -13,7 +15,7 @@
 //     * Rigorous Test :-)
 //     */
 //    @Test
-//    public void shouldAnswerWithTrue() {
+//    void shouldAnswerWithTrue() {
 //        Assertions.assertTrue(true);
 //    }
 //

--- a/meta-model/model-rss/src/test/java/com/acanx/meta/model/rss/AppTest.java
+++ b/meta-model/model-rss/src/test/java/com/acanx/meta/model/rss/AppTest.java
@@ -1,3 +1,5 @@
+package com.acanx.meta.model.rss.AppTest.java;
+
 //package com.acanx.meta.model;
 //
 //
@@ -13,7 +15,7 @@
 //     * Rigorous Test :-)
 //     */
 //    @Test
-//    public void shouldAnswerWithTrue() {
+//    void shouldAnswerWithTrue() {
 //        Assertions.assertTrue(true);
 //    }
 //

--- a/meta-model/model-security/src/test/java/com/acanx/meta/AppTest.java
+++ b/meta-model/model-security/src/test/java/com/acanx/meta/AppTest.java
@@ -1,3 +1,5 @@
+package com.acanx.meta.AppTest.java;
+
 //package com.acanx.meta;
 //
 //
@@ -13,7 +15,7 @@
 //     * Rigorous Test :-)
 //     */
 //    @Test
-//    public void shouldAnswerWithTrue() {
+//    void shouldAnswerWithTrue() {
 //        Assertions.assertTrue(true);
 //    }
 //

--- a/meta-model/model-sonatype/src/test/java/com/acanx/meta/model/sonatype/AppTest.java
+++ b/meta-model/model-sonatype/src/test/java/com/acanx/meta/model/sonatype/AppTest.java
@@ -1,3 +1,5 @@
+package com.acanx.meta.model.sonatype.AppTest.java;
+
 //package com.acanx.meta.model;
 //
 //
@@ -13,7 +15,7 @@
 //     * Rigorous Test :-)
 //     */
 //    @Test
-//    public void shouldAnswerWithTrue() {
+//    void shouldAnswerWithTrue() {
 //        Assertions.assertTrue(true);
 //    }
 //

--- a/meta-model/model-test/src/test/java/com/acanx/meta/model/test/AppTest.java
+++ b/meta-model/model-test/src/test/java/com/acanx/meta/model/test/AppTest.java
@@ -13,7 +13,7 @@ public class AppTest {
      * Rigorous Test :-)
      */
     @Test
-    public void shouldAnswerWithTrue() {
+    void shouldAnswerWithTrue() {
         Assertions.assertTrue(true);
     }
 

--- a/meta-model/model-wechat-work/src/test/java/com/acanx/meta/model/wechat/work/AppTest.java
+++ b/meta-model/model-wechat-work/src/test/java/com/acanx/meta/model/wechat/work/AppTest.java
@@ -1,3 +1,5 @@
+package com.acanx.meta.model.wechat.work.AppTest.java;
+
 //package com.acanx.meta.model;
 //
 //
@@ -13,7 +15,7 @@
 //     * Rigorous Test :-)
 //     */
 //    @Test
-//    public void shouldAnswerWithTrue() {
+//    void shouldAnswerWithTrue() {
 //        Assertions.assertTrue(true);
 //    }
 //

--- a/meta-model/model-ylmf/src/test/java/com/acanx/meta/model/AppTest.java
+++ b/meta-model/model-ylmf/src/test/java/com/acanx/meta/model/AppTest.java
@@ -13,7 +13,7 @@ public class AppTest {
      * Rigorous Test :-)
      */
     @Test
-    public void shouldAnswerWithTrue() {
+    void shouldAnswerWithTrue() {
         Assertions.assertTrue(true);
     }
 

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
@@ -118,7 +118,7 @@ public class ArtifactService {
     }
 
 
-    private static Project parseMavenProjectPomXmlContent(String pomContent) throws IOException, XmlPullParserException {
+    private static Project parseMavenProjectPomXmlContent(String pomContent) {
         XmlMapper xmlMapper = new XmlMapper();
         // 忽略未知属性
         xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/util/MavenArtifactUtil.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/util/MavenArtifactUtil.java
@@ -19,8 +19,7 @@ public class MavenArtifactUtil {
      */
     public static String getArtifactMetadataXmlFileUrl(String groupId, String artifactId) {
         String groupPath = groupId.replace(".", "/");
-        String reqUrl = MVNC.URL_MAVEN_CENTRAL_REPO + groupPath + "/" + artifactId.replace(".", "/") + "/maven-metadata.xml";
-        return reqUrl;
+        return MVNC.URL_MAVEN_CENTRAL_REPO + groupPath + "/" + artifactId.replace(".", "/") + "/maven-metadata.xml";
     }
 
     /**
@@ -31,8 +30,7 @@ public class MavenArtifactUtil {
      * @return
      */
     public static String getArtifactLatestVersionPomFileUrl(String groupId, String artifactId, String latestVersion) {
-        String pomFileUrl = String.format("%s%s/%s/%s/%s-%s.pom", MVNC.URL_MAVEN_CENTRAL_REPO, groupId.replace(".", "/"), artifactId, latestVersion, artifactId, latestVersion);
-        return pomFileUrl;
+        return String.format("%s%s/%s/%s/%s-%s.pom", MVNC.URL_MAVEN_CENTRAL_REPO, groupId.replace(".", "/"), artifactId, latestVersion, artifactId, latestVersion);
     }
 
     /**

--- a/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/AppTest.java
+++ b/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/AppTest.java
@@ -13,7 +13,7 @@ public class AppTest {
      * Rigorous Test :-)
      */
     @Test
-    public void shouldAnswerWithTrue() {
+    void shouldAnswerWithTrue() {
         Assertions.assertTrue(true);
     }
 


### PR DESCRIPTION
## LOW 级别修复
- S1220: 测试类添加 package 声明（5个文件）
- S4719: DingTalkSignUtil 使用 StandardCharsets.UTF_8
- S1130: ArtifactService 移除不可抛出的异常声明
- S1488: MavenArtifactUtil 直接返回表达式
- S1481: CopierProcessor 移除未使用变量
- S1104: DeepSeekRi 字段改为 private
- S117: DeepSeekRi 参数名 max_tokens → maxTokens

## INFO 级别修复
- S5786: 测试方法移除 public 修饰符（14个文件）

Closes #1714
Closes #1715