### PR TITLE
fix(code): System.out 替换为 Logger（SonarCloud S106）

### DIFF
--- a/meta-model/model-folo/src/main/java/com/acanx/meta/model/folo/App.java
+++ b/meta-model/model-folo/src/main/java/com/acanx/meta/model/folo/App.java
@@ -1,12 +1,17 @@
 package com.acanx.meta.model.folo;
 
+import java.util.logging.Logger;
+
 /**
  *
  * App
  *
  */
 public class App {
+
+    private static final Logger LOGGER = Logger.getLogger(App.class.getName());
+
     public static void main(String[] args) {
-        System.out.println("Hello World!");
+        LOGGER.info("Hello World!");
     }
 }

--- a/meta-model/model-ylmf/src/main/java/com/acanx/meta/model/ylmf/App.java
+++ b/meta-model/model-ylmf/src/main/java/com/acanx/meta/model/ylmf/App.java
@@ -1,12 +1,17 @@
 package com.acanx.meta.model.ylmf;
 
+import java.util.logging.Logger;
+
 /**
  *
  * App
  *
  */
 public class App {
+
+    private static final Logger LOGGER = Logger.getLogger(App.class.getName());
+
     public static void main(String[] args) {
-        System.out.println("Hello World!");
+        LOGGER.info("Hello World!");
     }
 }


### PR DESCRIPTION
## 修复内容

修复 SonarCloud 规则 java:S106（Standard outputs should not be used directly to log anything）

### 修改文件

- `meta-model/model-folo/src/main/java/com/acanx/meta/model/folo/App.java`
  - 添加 `java.util.logging.Logger`
  - `System.out.println` → `LOGGER.info`
- `meta-model/model-ylmf/src/main/java/com/acanx/meta/model/ylmf/App.java`
  - 同上

### 关联 Issue

Closes #1718

---
*由 BeeAgent 自动创建*