### PR TITLE
fix: 修复 AppTest.java 错误的 package 声明

### DIFF
--- a/meta-model/model-quote/src/test/java/com/acanx/meta/model/quote/AppTest.java
+++ b/meta-model/model-quote/src/test/java/com/acanx/meta/model/quote/AppTest.java
@@ -1,4 +1,4 @@
-package com.acanx.meta.model.quote.AppTest.java;
+package com.acanx.meta.model.quote.AppTest;
 
 //package com.acanx.meta.model;
 //

--- a/meta-model/model-rss/src/test/java/com/acanx/meta/model/rss/AppTest.java
+++ b/meta-model/model-rss/src/test/java/com/acanx/meta/model/rss/AppTest.java
@@ -1,4 +1,4 @@
-package com.acanx.meta.model.rss.AppTest.java;
+package com.acanx.meta.model.rss.AppTest;
 
 //package com.acanx.meta.model;
 //

--- a/meta-model/model-security/src/test/java/com/acanx/meta/AppTest.java
+++ b/meta-model/model-security/src/test/java/com/acanx/meta/AppTest.java
@@ -1,4 +1,4 @@
-package com.acanx.meta.AppTest.java;
+package com.acanx.meta;
 
 //package com.acanx.meta;
 //

--- a/meta-model/model-sonatype/src/test/java/com/acanx/meta/model/sonatype/AppTest.java
+++ b/meta-model/model-sonatype/src/test/java/com/acanx/meta/model/sonatype/AppTest.java
@@ -1,4 +1,4 @@
-package com.acanx.meta.model.sonatype.AppTest.java;
+package com.acanx.meta.model.sonatype.AppTest;
 
 //package com.acanx.meta.model;
 //

--- a/meta-model/model-wechat-work/src/test/java/com/acanx/meta/model/wechat/work/AppTest.java
+++ b/meta-model/model-wechat-work/src/test/java/com/acanx/meta/model/wechat/work/AppTest.java
@@ -1,4 +1,4 @@
-package com.acanx.meta.model.wechat.work.AppTest.java;
+package com.acanx.meta.model.wechat.work.AppTest;
 
 //package com.acanx.meta.model;
 //


### PR DESCRIPTION
修复 5 个 AppTest.java 文件中错误的 package 声明（.java 后缀被错误包含）。

影响文件：
- model-security/AppTest.java
- model-quote/AppTest.java
- model-rss/AppTest.java
- model-sonatype/AppTest.java
- model-wechat-work/AppTest.java