### PR TITLE
fix: 修复 DeepSeekRi 变量名引用错误

### DIFF
--- a/meta-model/model-deepseek/src/main/java/com/acanx/meta/model/deepseek/ri/DeepSeekRi.java
+++ b/meta-model/model-deepseek/src/main/java/com/acanx/meta/model/deepseek/ri/DeepSeekRi.java
@@ -26,7 +26,7 @@ public class DeepSeekRi {
         this.model = model;
         this.stream = stream;
         this.temperature = temperature;
-        this.maxTokens = max_tokens;
+        this.maxTokens = maxTokens;
         this.messages = messages;
     }
 


### PR DESCRIPTION
修复 max_tokens → maxTokens 重命名后遗漏的变量引用。

`this.maxTokens = max_tokens;` → `this.maxTokens = maxTokens;`