### PR TITLE
fix: ArtifactService 移除 catch 中不可达的 XmlPullParserException

### DIFF
--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
@@ -87,7 +87,7 @@ public class ArtifactService {
             String packagingType = "jar";
             try {
                 project = parseMavenProjectPomXmlContent(xmlResponse);
-            } catch (IOException | XmlPullParserException e) {
+            } catch (IOException e) {
                 throw new RuntimeException(e);
             }
             // System.out.println("Packaging type: " + project.getPackaging());


### PR DESCRIPTION
修复编译错误：exception XmlPullParserException is never thrown in body of corresponding try statement

移除 catch 块中不可达的 XmlPullParserException。