### PR TITLE
fix: 移除未使用的 XmlPullParserException catch 块（编译修复）

### DIFF
--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
@@ -13,7 +13,7 @@ import com.acanx.util.http.HResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
 
 import java.io.IOException;
 
@@ -87,7 +87,7 @@ public class ArtifactService {
             String packagingType = "jar";
             try {
                 project = parseMavenProjectPomXmlContent(xmlResponse);
-            } catch (IOException | XmlPullParserException e) {
+            } catch (IOException e) {
                 throw new RuntimeException(e);
             }
             // System.out.println("Packaging type: " + project.getPackaging());


### PR DESCRIPTION
## 修复内容

PR #1725 合并后  存在编译错误：



### 原因
 方法仅声明 ，不再抛出 。但 catch 块仍包含 。

### 修复
- 移除  中的 
- 移除未使用的 