### PR TITLE
fix: 还原 AppTest.java 为注释状态

### DIFF
--- a/meta-model/model-deepseek/src/test/java/com/acanx/meta/model/deepseek/AppTest.java
+++ b/meta-model/model-deepseek/src/test/java/com/acanx/meta/model/deepseek/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.model.deepseek;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-public class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}

--- a/meta-model/model-folo/src/test/java/com/acanx/meta/model/AppTest.java
+++ b/meta-model/model-folo/src/test/java/com/acanx/meta/model/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.model;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-public class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}

--- a/meta-model/model-gemini/src/test/java/com/acanx/meta/model/AppTest.java
+++ b/meta-model/model-gemini/src/test/java/com/acanx/meta/model/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.model;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}

--- a/meta-model/model-maven/src/test/java/com/acanx/meta/model/maven/AppTest.java
+++ b/meta-model/model-maven/src/test/java/com/acanx/meta/model/maven/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.model.maven;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-public class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}

--- a/meta-model/model-quote/src/test/java/com/acanx/meta/model/quote/AppTest.java
+++ b/meta-model/model-quote/src/test/java/com/acanx/meta/model/quote/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.model.quote;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}

--- a/meta-model/model-rss/src/test/java/com/acanx/meta/model/rss/AppTest.java
+++ b/meta-model/model-rss/src/test/java/com/acanx/meta/model/rss/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.model.rss;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}

--- a/meta-model/model-sonatype/src/test/java/com/acanx/meta/model/sonatype/AppTest.java
+++ b/meta-model/model-sonatype/src/test/java/com/acanx/meta/model/sonatype/AppTest.java
@@ -1,5 +1,3 @@
-package com.acanx.meta.model.sonatype.AppTest;
-
 //package com.acanx.meta.model;
 //
 //
@@ -15,7 +13,7 @@ package com.acanx.meta.model.sonatype.AppTest;
 //     * Rigorous Test :-)
 //     */
 //    @Test
-//    void shouldAnswerWithTrue() {
+//    public void shouldAnswerWithTrue() {
 //        Assertions.assertTrue(true);
 //    }
 //

--- a/meta-model/model-test/src/test/java/com/acanx/meta/model/test/AppTest.java
+++ b/meta-model/model-test/src/test/java/com/acanx/meta/model/test/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.model.test;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-public class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}

--- a/meta-model/model-wechat-work/src/test/java/com/acanx/meta/model/wechat/work/AppTest.java
+++ b/meta-model/model-wechat-work/src/test/java/com/acanx/meta/model/wechat/work/AppTest.java
@@ -1,5 +1,3 @@
-package com.acanx.meta.model.wechat.work.AppTest;
-
 //package com.acanx.meta.model;
 //
 //
@@ -15,7 +13,7 @@ package com.acanx.meta.model.wechat.work.AppTest;
 //     * Rigorous Test :-)
 //     */
 //    @Test
-//    void shouldAnswerWithTrue() {
+//    public void shouldAnswerWithTrue() {
 //        Assertions.assertTrue(true);
 //    }
 //

--- a/meta-model/model-ylmf/src/test/java/com/acanx/meta/model/AppTest.java
+++ b/meta-model/model-ylmf/src/test/java/com/acanx/meta/model/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.model;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-public class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}

--- a/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/AppTest.java
+++ b/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/AppTest.java
@@ -1,20 +1,20 @@
-package com.acanx.meta.component;
-
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-/**
- * Unit test for simple App.
- */
-public class AppTest {
-
-    /**
-     * Rigorous Test :-)
-     */
-    @Test
-    void shouldAnswerWithTrue() {
-        Assertions.assertTrue(true);
-    }
-
-}
+//package com.acanx.meta.model;
+//
+//
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//
+///**
+// * Unit test for simple App.
+// */
+//public class AppTest {
+//
+//    /**
+//     * Rigorous Test :-)
+//     */
+//    @Test
+//    public void shouldAnswerWithTrue() {
+//        Assertions.assertTrue(true);
+//    }
+//
+//}


### PR DESCRIPTION
还原被修改的 AppTest.java 文件为原始注释状态。

原因：这些测试文件是占位符，不包含实际测试逻辑。 uncommented 后因模块缺少 JUnit 依赖导致编译失败。

还原 11 个文件：
- model-quote, model-rss, model-sonatype, model-wechat-work
- model-deepseek, model-folo, model-gemini, model-maven
- model-test, model-ylmf, sdk-maven-artifact