### PR TITLE
fix: 为所有模块添加 JUnit 依赖

### DIFF
--- a/meta-model/model-quote/pom.xml
+++ b/meta-model/model-quote/pom.xml
@@ -48,6 +48,12 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/meta-model/model-quote/src/test/java/com/acanx/meta/model/quote/AppTest.java
+++ b/meta-model/model-quote/src/test/java/com/acanx/meta/model/quote/AppTest.java
@@ -1,6 +1,5 @@
 package com.acanx.meta.model.quote;
 
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/meta-model/model-rss/pom.xml
+++ b/meta-model/model-rss/pom.xml
@@ -47,6 +47,12 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/meta-model/model-rss/src/test/java/com/acanx/meta/model/rss/AppTest.java
+++ b/meta-model/model-rss/src/test/java/com/acanx/meta/model/rss/AppTest.java
@@ -1,6 +1,5 @@
 package com.acanx.meta.model.rss;
 
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/meta-model/model-security/pom.xml
+++ b/meta-model/model-security/pom.xml
@@ -46,6 +46,12 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/meta-model/model-sonatype/pom.xml
+++ b/meta-model/model-sonatype/pom.xml
@@ -49,6 +49,12 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/meta-model/model-sonatype/src/test/java/com/acanx/meta/model/sonatype/AppTest.java
+++ b/meta-model/model-sonatype/src/test/java/com/acanx/meta/model/sonatype/AppTest.java
@@ -1,22 +1,19 @@
-package com.acanx.meta.model.sonatype.AppTest;
+package com.acanx.meta.model.sonatype;
 
-//package com.acanx.meta.model;
-//
-//
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.Test;
-//
-///**
-// * Unit test for simple App.
-// */
-//public class AppTest {
-//
-//    /**
-//     * Rigorous Test :-)
-//     */
-//    @Test
-//    void shouldAnswerWithTrue() {
-//        Assertions.assertTrue(true);
-//    }
-//
-//}
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+class AppTest {
+
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    void shouldAnswerWithTrue() {
+        Assertions.assertTrue(true);
+    }
+
+}

--- a/meta-model/model-wechat-work/pom.xml
+++ b/meta-model/model-wechat-work/pom.xml
@@ -47,6 +47,12 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/meta-model/model-wechat-work/src/test/java/com/acanx/meta/model/wechat/work/AppTest.java
+++ b/meta-model/model-wechat-work/src/test/java/com/acanx/meta/model/wechat/work/AppTest.java
@@ -1,22 +1,19 @@
-package com.acanx.meta.model.wechat.work.AppTest;
+package com.acanx.meta.model.wechat.work;
 
-//package com.acanx.meta.model;
-//
-//
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.Test;
-//
-///**
-// * Unit test for simple App.
-// */
-//public class AppTest {
-//
-//    /**
-//     * Rigorous Test :-)
-//     */
-//    @Test
-//    void shouldAnswerWithTrue() {
-//        Assertions.assertTrue(true);
-//    }
-//
-//}
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+class AppTest {
+
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    void shouldAnswerWithTrue() {
+        Assertions.assertTrue(true);
+    }
+
+}


### PR DESCRIPTION
修复 AppTest.java 编译失败：package org.junit.jupiter.api does not exist

为以下模块添加 JUnit 5 依赖：
- model-quote
- model-rss
- model-sonatype
- model-wechat-work
- model-security

同时恢复被注释的 AppTest.java 文件为正常状态。