### PR TITLE
chore(deps): bump flink.version from 1.17.2 to 1.20.4 (编译验证)

### DIFF
--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -597,18 +597,18 @@
         <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-core</artifactId>
-        <version>1.17.2</version>
+        <version>1.20.4</version>
         <scope>provided</scope>
       </dependency>
         <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-clients</artifactId>
-        <version>1.17.2</version>
+        <version>1.20.4</version>
       </dependency>
         <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-java</artifactId>
-        <version>1.17.2</version>
+        <version>1.20.4</version>
       </dependency>
         <dependency>
         <groupId>org.apache.hadoop</groupId>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -109,7 +109,7 @@
         <lucense.version>10.4.0</lucense.version>
         <elasticsearch.version>9.4.0</elasticsearch.version>
 
-        <flink.version>1.17.2</flink.version>
+        <flink.version>1.20.4</flink.version>
         <hadoop.version>3.5.0</hadoop.version>
 
         <micrometer.version>1.16.5</micrometer.version>


### PR DESCRIPTION
## 概述

基于远程 `dependa` 分支拉取特性分支，合并 PR #1548 的 flink 依赖升级提交进行编译验证。

### 变更内容
- `flink.version`: 1.17.2 → 1.20.4（os-dependencies/pom.xml）
- flink-core, flink-clients, flink-java: 1.17.2 → 1.20.4（meta-bom/bom-aio/pom.xml）

### 关联
- 源 PR: #1548
- 目标分支: dependa

> ⚠️ 本机无 Java/Maven 环境，需 CI 编译验证通过后方可合并。
