### PR TITLE
chore(deps): bump com.alibaba:fastjson to 2.0.61 (编译验证)

### DIFF
--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -49,6 +49,8 @@
         <!-- Excel/Office 版本 -->
         <poi.version>5.5.1</poi.version>
         <easy-excel.version>4.0.3</easy-excel.version>
+        <fastjson.version>2.0.61</fastjson.version>
+        <fastjson2.version>2.0.61</fastjson2.version>
 
         <!-- 通用工具库版本 -->
         <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
## 概述

基于远程 `dependa` 分支拉取特性分支，合并 PR #1187 的 fastjson 依赖升级提交进行编译验证。

### 变更内容
- 新增 fastjson.version=2.0.61 和 fastjson2.version=2.0.61 属性定义（meta-bom/bom-mod/pom.xml）
- 解决了 dependa 分支中引用但未定义 fastjson.version/fastjson2.version 属性的问题

### 关联
- 源 PR: #1187
- 目标分支: dependa

> ⚠️ 本机无 Java/Maven 环境，需 CI 编译验证通过后方可合并。
