### PR TITLE
ci: rename branch dependabot -> dependa in MultiMavenJDKBranchCI

### DIFF
--- a/.github/workflows/MultiMavenJDKBranchCI.yml
+++ b/.github/workflows/MultiMavenJDKBranchCI.yml
@@ -3,7 +3,7 @@ name: MultiMavenJDKBranchCI
 on:
   push:
     branches:
-      - dependabot
+      - dependa
       - dev
       - main
       - feat-autoci
@@ -13,7 +13,7 @@ on:
       - '.gitignore'
   pull_request:
     branches:
-      - dependabot
+      - dependa
       - dev
       - main
       - feat-autoci
@@ -49,17 +49,17 @@ jobs:
             java: '25'
             os: ubuntu-latest      
             
-          - branch: dependabot
+          - branch: dependa
             java: '25'
             os: windows-latest
-          - branch: dependabot
+          - branch: dependa
             java: '25'
             os: ubuntu-latest      
             
-          - branch: dependabot
+          - branch: dependa
             java: '21'
             os: ubuntu-latest
-          - branch: dependabot
+          - branch: dependa
             java: '21'
             os: windows-latest
 
@@ -91,10 +91,10 @@ jobs:
           #   java: '11'
           #   os: windows-latest
             
-          # - branch: dependabot
+          # - branch: dependa
           #   java: '11'
           #   os: ubuntu-latest
-          # - branch: dependabot
+          # - branch: dependa
           #   java: '11'
           #   os: windows-latest
 


### PR DESCRIPTION
将 MultiMavenJDKBranchCI workflow 中所有 `dependabot` 分支引用改为 `dependa`，包括：

- push 触发分支
- pull_request 触发分支  
- matrix 中的分支名

此 PR 需要优先合并，否则依赖 dependa 分支的 CI 编译验证无法自动触发。