### PR TITLE
chore(deps): bump com.alibaba:fastjson to 2.0.61 (编译验证)

### DIFF
--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -49,6 +49,8 @@
         <!-- Excel/Office 版本 -->
         <poi.version>5.5.1</poi.version>
         <easy-excel.version>4.0.3</easy-excel.version>
+        <fastjson.version>2.0.61</fastjson.version>
+        <fastjson2.version>2.0.61</fastjson2.version>
 
         <!-- 通用工具库版本 -->
         <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
从上游仓库重新发起的 PR，替代原 #1761（fork 发起）。

fastjson/fastjson2 → 2.0.61，Maven 编译验证已通过。