### PR TITLE
fix: artifact name sanitize for upload-artifact (invalid /)

### DIFF
--- a/.github/workflows/ManualBranchCompileVerify.yml
+++ b/.github/workflows/ManualBranchCompileVerify.yml
@@ -74,11 +74,20 @@ jobs:
         working-directory: ${{ env.PROJECT_DIR }}
         run: mvn --batch-mode --update-snapshots clean compile test package
 
+      - name: SanitizeArtifactName
+        if: success()
+        id: sanitize
+        shell: bash
+        run: |
+          # Replace invalid characters (/ \ : " < > | * ?) with dash
+          safe=$(echo "${{ steps.resolve.outputs.branch }}" | tr '/\\:"<>|*?' '-' )
+          echo "artifact_name=app-${safe}-jdk${{ steps.resolve.outputs.java }}" >> "$GITHUB_OUTPUT"
+
       - name: UploadBuildArtifacts
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: app-${{ steps.resolve.outputs.branch }}-jdk${{ steps.resolve.outputs.java }}
+          name: ${{ steps.sanitize.outputs.artifact_name }}
           path: |
             ${{ env.PROJECT_DIR }}/**/target/*.jar
             ${{ env.PROJECT_DIR }}/**/target/*.war


### PR DESCRIPTION
## 问题

ManualBranchCompileVerify workflow 中 `upload-artifact@v4` 的 artifact name 直接使用了分支名，当分支名包含 `/`（如 dependabot 分支）时会报错：

```
Error: The artifact name is not valid: app-dependabot/maven/dependa/...-jdk25. Contains the following character: Forward slash /
```

## 修复

新增 `SanitizeArtifactName` 步骤，使用 `tr` 将非法字符替换为 `-`：

- 原名称：`app-dependabot/maven/dependa/org.graalvm.buildtools-utils-1.1.1-jdk25` ❌
- 修复后：`app-dependabot-maven-dependa-org.graalvm.buildtools-utils-1.1.1-jdk25` ✅

## 参考

- 失败日志：https://github.com/ACANX/MetaOpen/actions/runs/26716644735/job/78736285331