### PR TITLE
fix: 修复测试中使用系统时钟的问题 (java:S8692)

### DIFF
--- a/meta-component/component-schedule/src/test/java/com/acanx/meta/component/schedule/util/ExecutionTimeUtilTest.java
+++ b/meta-component/component-schedule/src/test/java/com/acanx/meta/component/schedule/util/ExecutionTimeUtilTest.java
@@ -2,20 +2,34 @@ package com.acanx.meta.component.schedule.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class ExecutionTimeUtilTest {
 
     @Test
     void nextFire() {
-        ZonedDateTime nextFire = ExecutionTimeUtil.nextFire(ZonedDateTime.now(), ZonedDateTime.now().minusSeconds(1400), "0 3 20 * * ?");
+        ZonedDateTime fixedNow = ZonedDateTime.of(2026, 6, 17, 10, 0, 0, 0, ZoneId.systemDefault());
+        ZonedDateTime lastFire = fixedNow.minusSeconds(1400);
+        ZonedDateTime nextFire = ExecutionTimeUtil.nextFire(fixedNow, lastFire, "0 3 20 * * ?");
+        assertNotNull(nextFire, "下次触发时间不应为空");
+        assertEquals(20, nextFire.getHour(), "触发时间应为20时");
+        assertEquals(3, nextFire.getMinute(), "触发时间应为20:03");
+        assertTrue(nextFire.isAfter(fixedNow), "触发时间应在当前时间之后");
         System.out.println("下次触发时间: " + nextFire.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
     }
 
     @Test
     void nextFire2() {
-        ZonedDateTime nextFire = ExecutionTimeUtil.nextFire(ZonedDateTime.now(), ZonedDateTime.now().minusSeconds(1400), 20*3600);
+        ZonedDateTime fixedNow = ZonedDateTime.of(2026, 6, 17, 10, 0, 0, 0, ZoneId.systemDefault());
+        ZonedDateTime lastFire = fixedNow.minusSeconds(1400);
+        ZonedDateTime nextFire = ExecutionTimeUtil.nextFire(fixedNow, lastFire, 20 * 3600);
+        assertNotNull(nextFire, "下次触发时间不应为空");
+        assertEquals(fixedNow.plusSeconds(20 * 3600L), nextFire, "固定间隔触发时间应为当前时间 + 20小时");
+        assertTrue(nextFire.isAfter(lastFire), "触发时间应在上次执行时间之后");
         System.out.println("下次触发时间: " + nextFire.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
     }
 }


### PR DESCRIPTION
## 问题

SonarCloud 报告了 3 个 java:S8692 规则问题（RELIABILITY 影响）：

| Issue | 方法 | 问题 |
|-------|------|------|
| AZ7Bw-7JGmv_3eIbiHy7 | `nextFire()` | 使用 `ZonedDateTime.now()` 获取系统时钟 |
| AZ7Bw-7JGmv_3eIbiHy8 | `nextFire()` | 同上（不同偏移） |
| AZ7Bw-7JGmv_3eIbiHy9 | `nextFire2()` | 使用 `ZonedDateTime.now()` 获取系统时钟 |

## 修复

1. **使用固定时间** — 将 `ZonedDateTime.now()` 替换为固定时间 `ZonedDateTime.of(2026, 6, 17, 10, 0, 0, 0, ZoneId.systemDefault())`，确保测试可重复执行
2. **添加断言** — 替代仅打印到控制台，验证触发时间不为空、时间正确、在当前时间之后

Closes:
- AZ7Bw-7JGmv_3eIbiHy7
- AZ7Bw-7JGmv_3eIbiHy8
- AZ7Bw-7JGmv_3eIbiHy9