### PR TITLE
fix: 修复 GeminiConstTest 测试失败

### DIFF
--- a/meta-model/model-gemini/src/test/java/com/acanx/meta/c/GeminiConstTest.java
+++ b/meta-model/model-gemini/src/test/java/com/acanx/meta/c/GeminiConstTest.java
@@ -64,8 +64,8 @@ class GeminiConstTest {
     }
 
     @Test
-    void privateConstructorShouldNotBeInstantiable() {
-        assertThrows(NoSuchMethodException.class, () -> {
+    void privateConstructorShouldNotBeAccessible() {
+        assertThrows(IllegalAccessException.class, () -> {
             GeminiConst.class.getDeclaredConstructor().newInstance();
         });
     }


### PR DESCRIPTION
## 修复

GeminiConstTest.privateConstructorShouldNotBeInstantiable 测试断言异常类型错误。

-  → 
- 私有构造器存在（ 能找到），但未调用 ，所以  抛出 

这是 PR #1947 合并后遗留的测试修复。