### PR TITLE
fix: base-exception 模块缺少 JUnit 测试依赖

### DIFF
--- a/base/base-exception/pom.xml
+++ b/base/base-exception/pom.xml
@@ -54,6 +54,14 @@
             <artifactId>base-error</artifactId>
             <version>${revision}</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## 问题

PR #1947 合并后，base-exception 模块新增了测试类（BaseExceptionTest、BusinessExceptionTest、SystemExceptionTest），但该模块的 pom.xml 未声明 junit-jupiter 依赖，导致 CI 编译失败：

```
package org.junit.jupiter.api does not exist
```

## 修复

在 base-exception/pom.xml 中添加 test scope 的 junit-jupiter 依赖，参照 base-file 模块的配置方式。