### PR TITLE
fix: base-exception 模块添加 JUnit 测试依赖

### DIFF
--- a/base/base-exception/pom.xml
+++ b/base/base-exception/pom.xml
@@ -54,6 +54,14 @@
             <artifactId>base-error</artifactId>
             <version>${revision}</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>6.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## 问题

base-exception 模块新增的测试类编译失败：
```
package org.junit.jupiter.api does not exist
```

## 修复

在 base-exception/pom.xml 中添加 test scope 的 junit-jupiter 依赖，版本号写死为 6.1.0（与根 pom 中定义的 junit-jupiter.version 一致）。

> 注：使用写死版本号而非 ${junit-jupiter.version} 变量引用，避免变量在模块作用域内解析异常的问题。