### PR TITLE
fix: 将 bom-graalvm 版本号提取为属性，避免同步时被降级

### DIFF
--- a/meta-bom/bom-aio-origin/pom.xml
+++ b/meta-bom/bom-aio-origin/pom.xml
@@ -87,7 +87,7 @@
             <dependency>
                 <groupId>com.acanx.meta.component</groupId>
                 <artifactId>bom-graalvm</artifactId>
-                <version>25.0.8.1</version>
+                <version>${bom-graalvm.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -46,6 +46,7 @@
         <meta-open.version>0.8.7</meta-open.version>
         <autil.version>1.3.0</autil.version>
         <module.version>0.4.2</module.version>
+        <bom-graalvm.version>25.0.8.6</bom-graalvm.version>
 
         <java.version>21</java.version>
         <maven-compiler-source.version>21</maven-compiler-source.version>


### PR DESCRIPTION
## 问题

bom-aio-origin 中 bom-graalvm 的版本号是**硬编码**的 `25.0.8.1`，该版本中的 GraalVM buildtools 三件套为旧版 `1.0.0`。

每次 `UpdateBOMAIODependencies` 工作流同步 bom-aio-origin → bom-aio 时，会把 bom-aio 中已升级到 `1.1.2` 的版本**覆盖回 `1.0.0`**，导致版本降级。

## 修复

1. 在 `bom-aio-origin/pom.xml` 中添加属性 `<bom-graalvm.version>25.0.8.6</bom-graalvm.version>`
2. 引用方式从硬编码 `25.0.8.1` 改为 `${bom-graalvm.version}`
3. 后续升级 bom-graalvm 时只需修改这一个属性值

> 注：属性放在 bom-aio-origin 自身而非 meta-bom/pom.xml 中，因为其 parent 被注释掉了，无法继承父 POM 的属性。