### PR TITLE
chore(deps): 依赖构件版本升级汇总 (dependa → dev)

### DIFF
--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -876,7 +876,7 @@
         <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-api</artifactId>
-        <version>4.44.0</version>
+        <version>4.45.0</version>
       </dependency>
         <dependency>
         <groupId>org.thymeleaf</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2399,13 +2399,13 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ses</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
@@ -2571,7 +2571,7 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-functiongraph</artifactId>
-        <version>3.1.202</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.google.cloud.functions</groupId>
@@ -2627,12 +2627,12 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-core</artifactId>
-        <version>3.1.202</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-apig</artifactId>
-        <version>3.1.202</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>
@@ -2666,59 +2666,59 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudwatch</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>costexplorer</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sqs</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sns</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>scheduler</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -349,7 +349,7 @@
         <dependency>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.10.0</version>
+        <version>0.11.0</version>
       </dependency>
         <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -663,7 +663,7 @@
         <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
-        <version>11.0.22</version>
+        <version>11.0.23</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -1325,7 +1325,7 @@
         <dependency>
         <groupId>org.mybatis</groupId>
         <artifactId>mybatis-spring</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2571,7 +2571,7 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-functiongraph</artifactId>
-        <version>3.1.201</version>
+        <version>3.1.202</version>
       </dependency>
         <dependency>
         <groupId>com.google.cloud.functions</groupId>
@@ -2627,12 +2627,12 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-core</artifactId>
-        <version>3.1.201</version>
+        <version>3.1.202</version>
       </dependency>
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-apig</artifactId>
-        <version>3.1.201</version>
+        <version>3.1.202</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -1198,29 +1198,29 @@
         <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-all</artifactId>
-        <version>1.82.0</version>
+        <version>1.82.1</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-api</artifactId>
-        <version>1.82.0</version>
+        <version>1.82.1</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
-        <version>1.82.0</version>
+        <version>1.82.1</version>
       </dependency>
         <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-protobuf</artifactId>
-        <version>1.82.0</version>
+        <version>1.82.1</version>
       </dependency>
         <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-stub</artifactId>
-        <version>1.82.0</version>
+        <version>1.82.1</version>
       </dependency>
         <dependency>
         <groupId>org.apache.dubbo</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -895,7 +895,7 @@
         <dependency>
         <groupId>org.redisson</groupId>
         <artifactId>redisson</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -764,7 +764,7 @@
         <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>
-        <version>10.4.0</version>
+        <version>10.5.0</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -1125,7 +1125,7 @@
         <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-access</artifactId>
-        <version>1.5.34</version>
+        <version>1.5.37</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
@@ -2389,12 +2389,12 @@
         <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.5.34</version>
+        <version>1.5.37</version>
       </dependency>
         <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.5.34</version>
+        <version>1.5.37</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2733,7 +2733,7 @@
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
       </dependency>
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -376,7 +376,7 @@
         <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.31.0-GA</version>
+        <version>3.32.0-GA</version>
         <scope>compile</scope>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -642,7 +642,7 @@
         <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka_2.13</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2733,18 +2733,18 @@
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.2</version>
       </dependency>
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>utils</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.2</version>
         <scope>runtime</scope>
       </dependency>
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>graalvm-reachability-metadata</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.2</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -857,7 +857,7 @@
         <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>7.4.2.Final</version>
+        <version>7.4.3.Final</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2571,7 +2571,7 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-functiongraph</artifactId>
-        <version>3.1.200</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.google.cloud.functions</groupId>
@@ -2627,12 +2627,12 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-core</artifactId>
-        <version>3.1.200</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-apig</artifactId>
-        <version>3.1.200</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -1578,32 +1578,32 @@
         <dependency>
         <groupId>de.codecentric</groupId>
         <artifactId>spring-boot-admin-server</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
       </dependency>
         <dependency>
         <groupId>de.codecentric</groupId>
         <artifactId>spring-boot-admin-server-ui</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
       </dependency>
         <dependency>
         <groupId>de.codecentric</groupId>
         <artifactId>spring-boot-admin-client</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
       </dependency>
         <dependency>
         <groupId>de.codecentric</groupId>
         <artifactId>spring-boot-admin-starter-client</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
       </dependency>
         <dependency>
         <groupId>de.codecentric</groupId>
         <artifactId>spring-boot-admin-starter-server</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
       </dependency>
         <dependency>
         <groupId>de.codecentric</groupId>
         <artifactId>spring-boot-admin-server-cloud</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
       </dependency>
         <dependency>
         <groupId>org.springframework.security</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2738,7 +2738,7 @@
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>utils</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
         <scope>runtime</scope>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2723,7 +2723,7 @@
         <dependency>
         <groupId>com.aliyun</groupId>
         <artifactId>fc20230330</artifactId>
-        <version>4.7.6</version>
+        <version>4.7.7</version>
       </dependency>
         <dependency>
         <groupId>org.graalvm.nativeimage</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2338,7 +2338,7 @@
         <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-annotations-api</artifactId>
-        <version>11.0.22</version>
+        <version>11.0.23</version>
         <scope>compile</scope>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -836,7 +836,7 @@
         <dependency>
         <groupId>io.undertow</groupId>
         <artifactId>undertow-core</artifactId>
-        <version>2.4.1.Final</version>
+        <version>2.4.2.Final</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2399,13 +2399,13 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ses</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
@@ -2666,59 +2666,59 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudwatch</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>costexplorer</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sqs</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sns</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>scheduler</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>2.46.11</version>
+        <version>2.46.15</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2355,7 +2355,7 @@
         <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
-        <version>6.1.0</version>
+        <version>6.1.1</version>
         <scope>test</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -975,13 +975,13 @@
         <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>6.1.0</version>
+        <version>6.1.1</version>
         <scope>test</scope>
       </dependency>
         <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>6.1.0</version>
+        <version>6.1.1</version>
         <scope>test</scope>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2592,7 +2592,7 @@
         <dependency>
         <groupId>com.larksuite.oapi</groupId>
         <artifactId>oapi-sdk</artifactId>
-        <version>2.8.2</version>
+        <version>2.8.3</version>
       </dependency>
         <dependency>
         <groupId>com.brevo</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2399,13 +2399,13 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ses</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
@@ -2666,59 +2666,59 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudwatch</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>costexplorer</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sqs</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sns</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>scheduler</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>2.46.15</version>
+        <version>2.46.17</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2744,7 +2744,7 @@
         <dependency>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>graalvm-reachability-metadata</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -747,7 +747,7 @@
         <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>9.1.0.Final</version>
+        <version>9.1.1.Final</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -857,7 +857,7 @@
         <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>7.4.1.Final</version>
+        <version>7.4.2.Final</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -649,7 +649,7 @@
         <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -1008,7 +1008,7 @@
         <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
       </dependency>
         <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
@@ -1023,12 +1023,12 @@
         <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
       </dependency>
         <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-reactive</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
       </dependency>
         <dependency>
         <groupId>jakarta.annotation</groupId>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2637,7 +2637,7 @@
         <dependency>
         <groupId>com.aliyun</groupId>
         <artifactId>alibabacloud-oss-v2</artifactId>
-        <version>0.4.1</version>
+        <version>0.5.0</version>
         <scope>compile</scope>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -1162,13 +1162,13 @@
         <dependency>
         <groupId>org.commonmark</groupId>
         <artifactId>commonmark</artifactId>
-        <version>0.28.0</version>
+        <version>0.29.0</version>
         <optional>true</optional>
       </dependency>
         <dependency>
         <groupId>org.commonmark</groupId>
         <artifactId>commonmark-ext-gfm-tables</artifactId>
-        <version>0.28.0</version>
+        <version>0.29.0</version>
         <optional>true</optional>
       </dependency>
         <dependency>

--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2592,7 +2592,7 @@
         <dependency>
         <groupId>com.larksuite.oapi</groupId>
         <artifactId>oapi-sdk</artifactId>
-        <version>2.8.1</version>
+        <version>2.8.2</version>
       </dependency>
         <dependency>
         <groupId>com.brevo</groupId>

--- a/meta-bom/bom-cf/pom.xml
+++ b/meta-bom/bom-cf/pom.xml
@@ -127,8 +127,9 @@
                 <version>${fc-java-event.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.aliyun</groupId>
+                <artifactId>fc20230330</artifactId>
                 <version>4.7.7</version>
->>>>>>> origin/dependa
             </dependency>
 
             <!-- tencentcloud -->

--- a/meta-bom/bom-cf/pom.xml
+++ b/meta-bom/bom-cf/pom.xml
@@ -129,7 +129,7 @@
             <dependency>
                 <groupId>com.aliyun</groupId>
                 <artifactId>fc20230330</artifactId>
-                <version>4.7.6</version>
+                <version>4.7.7</version>
             </dependency>
 
             <!-- tencentcloud -->

--- a/meta-bom/bom-cf/pom.xml
+++ b/meta-bom/bom-cf/pom.xml
@@ -127,9 +127,8 @@
                 <version>${fc-java-event.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.aliyun</groupId>
-                <artifactId>fc20230330</artifactId>
                 <version>4.7.7</version>
+>>>>>>> origin/dependa
             </dependency>
 
             <!-- tencentcloud -->

--- a/meta-bom/bom-deamon/pom.xml
+++ b/meta-bom/bom-deamon/pom.xml
@@ -1470,7 +1470,7 @@
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>9.1.0.Final</version>
+                <version>9.1.1.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.dubbo</groupId>

--- a/meta-bom/bom-deamon/pom.xml
+++ b/meta-bom/bom-deamon/pom.xml
@@ -531,7 +531,7 @@
             <dependency>
                 <groupId>org.mybatis</groupId>
                 <artifactId>mybatis-spring</artifactId>
-                <version>4.0.0</version>
+                <version>4.1.0</version>
             </dependency>
 
 

--- a/meta-bom/bom-deamon/pom.xml
+++ b/meta-bom/bom-deamon/pom.xml
@@ -1486,7 +1486,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.79.Final</version>
+                <version>2.0.80.Final</version>
             </dependency>
 
 

--- a/meta-bom/bom-deamon/pom.xml
+++ b/meta-bom/bom-deamon/pom.xml
@@ -1703,7 +1703,7 @@
                   <dependency>
                       <groupId>org.apache.tomcat</groupId>
                       <artifactId>tomcat-annotations-api</artifactId>
-                      <version>11.0.22</version>
+                      <version>11.0.23</version>
                       <scope>compile</scope>
                   </dependency>
 

--- a/meta-bom/bom-graalvm/pom.xml
+++ b/meta-bom/bom-graalvm/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>
-            <version>25.0.3</version>
+            <version>25.1.3</version>
             <scope>provided</scope><!-- 添加 provided 作用域 -->
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.graalvm.nativeimage/svm -->

--- a/meta-bom/bom-graalvm/pom.xml
+++ b/meta-bom/bom-graalvm/pom.xml
@@ -90,7 +90,7 @@
             <dependency>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>graalvm-reachability-metadata</artifactId>
-                <version>1.1.2</version>
+                <version>1.1.3</version>
                 <scope>runtime</scope>
             </dependency>
         </dependencies>

--- a/meta-bom/bom-graalvm/pom.xml
+++ b/meta-bom/bom-graalvm/pom.xml
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <version>1.1.2</version>
+                <version>1.1.3</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.graalvm.buildtools/utils -->
             <dependency>

--- a/meta-bom/bom-graalvm/pom.xml
+++ b/meta-bom/bom-graalvm/pom.xml
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>utils</artifactId>
-                <version>1.1.2</version>
+                <version>1.1.3</version>
                 <scope>runtime</scope>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.graalvm.buildtools/graalvm-reachability-metadata -->

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- 第三方 SDK 版本 -->
         <java-function-invoker.version>2.0.1</java-function-invoker.version>
-        <oapi-sdk.version>2.8.2</oapi-sdk.version>
+        <oapi-sdk.version>2.8.3</oapi-sdk.version>
         <brevo.version>1.1.7</brevo.version>
         <ipinfo-api.version>3.4.0</ipinfo-api.version>
         <longport-openapi-sdk.version>3.0.23</longport-openapi-sdk.version>

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -753,7 +753,7 @@
                   <dependency>
                       <groupId>com.aliyun</groupId>
                       <artifactId>alibabacloud-oss-v2</artifactId>
-                      <version>0.4.1</version>
+                      <version>0.5.0</version>
                       <scope>compile</scope>
                   </dependency>
                   <!-- Source: https://mvnrepository.com/artifact/com.huaweicloud/esdk-obs-java -->

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -121,7 +121,7 @@
         <oapi-sdk.version>2.8.3</oapi-sdk.version>
         <brevo.version>1.1.7</brevo.version>
         <ipinfo-api.version>3.4.0</ipinfo-api.version>
-        <longport-openapi-sdk.version>3.0.23</longport-openapi-sdk.version>
+        <longport-openapi-sdk.version>4.3.3</longport-openapi-sdk.version>
         <bcprov-jdk18on.version>1.84</bcprov-jdk18on.version>
 
         <!-- BGMProvider 版本 -->

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- 第三方 SDK 版本 -->
         <java-function-invoker.version>2.0.1</java-function-invoker.version>
-        <oapi-sdk.version>2.8.1</oapi-sdk.version>
+        <oapi-sdk.version>2.8.2</oapi-sdk.version>
         <brevo.version>1.1.7</brevo.version>
         <ipinfo-api.version>3.4.0</ipinfo-api.version>
         <longport-openapi-sdk.version>3.0.23</longport-openapi-sdk.version>

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -89,7 +89,7 @@
 
         <!-- Cloud SDK 版本 -->
         <tencentcloud-sdk-java-scf.version>3.1.1469</tencentcloud-sdk-java-scf.version>
-        <tencentcloud-sdk-java-ses.version>3.1.1482</tencentcloud-sdk-java-ses.version>
+        <tencentcloud-sdk-java-ses.version>3.1.1494</tencentcloud-sdk-java-ses.version>
         <fc-java-core.version>1.4.1</fc-java-core.version>
         <fc-java-event.version>1.2.0</fc-java-event.version>
         <scf-java-events.version>0.0.4</scf-java-events.version>

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -102,7 +102,7 @@
         <bytebuddy.version>1.18.10</bytebuddy.version>
 
         <!-- 其他版本 -->
-        <graal-sdk.version>25.0.3</graal-sdk.version>
+        <graal-sdk.version>25.1.3</graal-sdk.version>
         <functions-framework.version>2.0.1</functions-framework.version>
         <jspecify.version>1.0.0</jspecify.version>
         <jakarta-servlet.version>6.1.0</jakarta-servlet.version>

--- a/meta-bom/bom-mod/pom.xml
+++ b/meta-bom/bom-mod/pom.xml
@@ -99,7 +99,7 @@
         <qiniu-java-sdk.version>7.19.0</qiniu-java-sdk.version>
 
         <!-- ByteCode 版本 -->
-        <bytebuddy.version>1.18.10</bytebuddy.version>
+        <bytebuddy.version>1.18.11</bytebuddy.version>
 
         <!-- 其他版本 -->
         <graal-sdk.version>25.1.3</graal-sdk.version>

--- a/meta-bom/bom-sdk/pom.xml
+++ b/meta-bom/bom-sdk/pom.xml
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>com.tencentcloudapi</groupId>
                 <artifactId>tencentcloud-sdk-java-ses</artifactId>
-                <version>3.1.1482</version>
+                <version>3.1.1494</version>
             </dependency>
             <dependency>
                 <groupId>com.qcloud</groupId>

--- a/meta-bom/bom-sdk/pom.xml
+++ b/meta-bom/bom-sdk/pom.xml
@@ -131,7 +131,7 @@
             <dependency>
                 <groupId>com.qcloud</groupId>
                 <artifactId>cos_api</artifactId>
-                <version>5.6.269</version>
+                <version>5.6.271</version>
                 <scope>compile</scope>
                 <exclusions>
                     <exclusion>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -265,7 +265,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.46.12</awssdk.version>
+        <awssdk.version>2.46.14</awssdk.version>
         <huaweicloud-sdk.version>3.1.200</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -195,7 +195,7 @@
 
         <!-- Markdown 相关 -->
         <commonmark.version>0.29.0</commonmark.version>
-        <cos_api.version>5.6.269</cos_api.version>
+        <cos_api.version>5.6.271</cos_api.version>
         <grpc.version>1.82.1</grpc.version>
         <protobuf-java.version>4.35.1</protobuf-java.version>
         <protoc.version>4.33.0</protoc.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -278,9 +278,8 @@
         <logback.version>1.5.37</logback.version>
         <!--  日志依赖  -->
 
-        <junit-jupiter.version>6.1.1</junit-jupiter.version>
-        <junit-platform.version>6.1.0</junit-platform.version>
         <junit-vintage-engine.version>6.1.1</junit-vintage-engine.version>
+>>>>>>> origin/dependa
         <junit.version>4.13.2</junit.version>
 
         <!-- Spring Data 版本 -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -194,7 +194,7 @@
         <openjfx.version>25.0.1</openjfx.version>
 
         <!-- Markdown 相关 -->
-        <commonmark.version>0.28.0</commonmark.version>
+        <commonmark.version>0.29.0</commonmark.version>
         <cos_api.version>5.6.269</cos_api.version>
         <grpc.version>1.82.0</grpc.version>
         <protobuf-java.version>4.35.1</protobuf-java.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -262,8 +262,7 @@
         <selenium-futu.version>4.39.0</selenium-futu.version>
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
-
-        <awssdk.version>2.46.17</awssdk.version>
+>>>>>>> origin/dependa
 
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -273,7 +273,7 @@
         <slf4j-api.version>2.0.18</slf4j-api.version>
         <jul-to-slf4j>2.0.18</jul-to-slf4j>
         <log4j-over-slf4j>2.0.18</log4j-over-slf4j>
-        <log4j.version>2.26.0</log4j.version>
+        <log4j.version>2.26.1</log4j.version>
         <log4j-to-slf4j>2.26.0</log4j-to-slf4j>
         <logback.version>1.5.37</logback.version>
         <!--  日志依赖  -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -265,7 +265,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.46.11</awssdk.version>
+        <awssdk.version>2.46.12</awssdk.version>
         <huaweicloud-sdk.version>3.1.200</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -134,7 +134,7 @@
         <spring-cloud-stream-reactive.version>2.2.1.RELEASE</spring-cloud-stream-reactive.version>
         <spring-cloud-openfeign.version>4.2.0</spring-cloud-openfeign.version>
         <spring-cloud-netflix.version>4.2.0</spring-cloud-netflix.version>
-        <spring-boot-admin.version>4.1.0</spring-boot-admin.version>
+        <spring-boot-admin.version>4.1.1</spring-boot-admin.version>
 
 
         <mybatis-spring.version>3.0.4</mybatis-spring.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -280,7 +280,7 @@
 
         <junit-jupiter.version>6.1.1</junit-jupiter.version>
         <junit-platform.version>6.1.0</junit-platform.version>
-        <junit-vintage-engine.version>6.1.0</junit-vintage-engine.version>
+        <junit-vintage-engine.version>6.1.1</junit-vintage-engine.version>
         <junit.version>4.13.2</junit.version>
 
         <!-- Spring Data 版本 -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -275,7 +275,7 @@
         <log4j-over-slf4j>2.0.18</log4j-over-slf4j>
         <log4j.version>2.26.0</log4j.version>
         <log4j-to-slf4j>2.26.0</log4j-to-slf4j>
-        <logback.version>1.5.34</logback.version>
+        <logback.version>1.5.35</logback.version>
         <!--  日志依赖  -->
 
         <junit-jupiter.version>6.1.0</junit-jupiter.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -262,7 +262,6 @@
         <selenium-futu.version>4.39.0</selenium-futu.version>
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
->>>>>>> origin/dependa
 
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>
@@ -270,12 +269,11 @@
         <jul-to-slf4j>2.0.18</jul-to-slf4j>
         <log4j-over-slf4j>2.0.18</log4j-over-slf4j>
         <log4j.version>2.26.1</log4j.version>
-        <log4j-to-slf4j>2.26.0</log4j-to-slf4j>
+        <log4j-to-slf4j>2.26.1</log4j-to-slf4j>
         <logback.version>1.5.37</logback.version>
         <!--  日志依赖  -->
 
         <junit-vintage-engine.version>6.1.1</junit-vintage-engine.version>
->>>>>>> origin/dependa
         <junit.version>4.13.2</junit.version>
 
         <!-- Spring Data 版本 -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -263,6 +263,8 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
+        <awssdk.version>2.46.21</awssdk.version>
+        <huaweicloud-sdk.version>3.1.201</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -196,7 +196,7 @@
         <!-- Markdown 相关 -->
         <commonmark.version>0.29.0</commonmark.version>
         <cos_api.version>5.6.269</cos_api.version>
-        <grpc.version>1.82.0</grpc.version>
+        <grpc.version>1.82.1</grpc.version>
         <protobuf-java.version>4.35.1</protobuf-java.version>
         <protoc.version>4.33.0</protoc.version>
         <guava.version>33.6.0-jre</guava.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -265,7 +265,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.46.15</awssdk.version>
+        <awssdk.version>2.46.17</awssdk.version>
         <huaweicloud-sdk.version>3.1.201</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -264,7 +264,6 @@
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
         <awssdk.version>2.46.17</awssdk.version>
-        <huaweicloud-sdk.version>3.1.202</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -266,7 +266,7 @@
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
         <awssdk.version>2.46.17</awssdk.version>
-        <huaweicloud-sdk.version>3.1.201</huaweicloud-sdk.version>
+        <huaweicloud-sdk.version>3.1.202</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -217,6 +217,8 @@
         <httpclient.version>4.5.14</httpclient.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <httpasyncclient.version>4.1.5</httpasyncclient.version>
+        <httpclient5.version>5.6.2</httpclient5.version>
+        <httpcore5.version>5.4.3</httpcore5.version>
         <jsoup.version>1.22.2</jsoup.version>
 
         <snakeyaml.version>2.7</snakeyaml.version>
@@ -277,6 +279,8 @@
         <!--  日志依赖  -->
 
         <junit-vintage-engine.version>6.1.1</junit-vintage-engine.version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
+        <junit-platform.version>6.1.1</junit-platform.version>
         <junit.version>4.13.2</junit.version>
 
         <!-- Spring Data 版本 -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -263,6 +263,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
+
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>
         <slf4j-api.version>2.0.18</slf4j-api.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -266,7 +266,7 @@
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
         <awssdk.version>2.46.12</awssdk.version>
-        <huaweicloud-sdk.version>3.1.200</huaweicloud-sdk.version>
+        <huaweicloud-sdk.version>3.1.201</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -266,7 +266,7 @@
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
         <awssdk.version>2.46.14</awssdk.version>
-        <huaweicloud-sdk.version>3.1.200</huaweicloud-sdk.version>
+        <huaweicloud-sdk.version>3.1.201</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->
         <slf4j.version>2.0.18</slf4j.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -278,7 +278,7 @@
         <logback.version>1.5.37</logback.version>
         <!--  日志依赖  -->
 
-        <junit-jupiter.version>6.1.0</junit-jupiter.version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
         <junit-platform.version>6.1.0</junit-platform.version>
         <junit-vintage-engine.version>6.1.0</junit-vintage-engine.version>
         <junit.version>4.13.2</junit.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -213,8 +213,6 @@
         <jackson.version>2.22.0</jackson.version>
         <!--  JSON -->
               
-        <httpclient5.version>5.6.1</httpclient5.version>
-        <httpcore5.version>5.4.3</httpcore5.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpclient.version>4.5.14</httpclient.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -265,7 +265,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.46.14</awssdk.version>
+        <awssdk.version>2.46.15</awssdk.version>
         <huaweicloud-sdk.version>3.1.201</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -214,7 +214,7 @@
         <!--  JSON -->
               
         <httpclient5.version>5.6.1</httpclient5.version>
-        <httpcore5.version>5.4.2</httpcore5.version>
+        <httpcore5.version>5.4.3</httpcore5.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpclient.version>4.5.14</httpclient.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -109,7 +109,7 @@
         <mybatis.version>3.5.19</mybatis.version>
 
         <groovy.version>4.0.24</groovy.version>
-        <javassist.version>3.31.0-GA</javassist.version>
+        <javassist.version>3.32.0-GA</javassist.version>
         <aspectj.version>1.9.22.1</aspectj.version>
         <byte-buddy.version>1.17.5</byte-buddy.version>
         <classmate.version>1.7.0</classmate.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -275,7 +275,7 @@
         <log4j-over-slf4j>2.0.18</log4j-over-slf4j>
         <log4j.version>2.26.0</log4j.version>
         <log4j-to-slf4j>2.26.0</log4j-to-slf4j>
-        <logback.version>1.5.35</logback.version>
+        <logback.version>1.5.37</logback.version>
         <!--  日志依赖  -->
 
         <junit-jupiter.version>6.1.0</junit-jupiter.version>

--- a/meta-model/model-folo/pom.xml
+++ b/meta-model/model-folo/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- <maven.compiler.release>21</maven.compiler.release> -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-       <junit-jupiter.version>6.1.0</junit-jupiter.version>
+       <junit-jupiter.version>6.1.1</junit-jupiter.version>
     </properties>
 
     <dependencies>

--- a/meta-model/model-ylmf/pom.xml
+++ b/meta-model/model-ylmf/pom.xml
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- <maven.compiler.release>21</maven.compiler.release> -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <junit-jupiter.version>6.1.0</junit-jupiter.version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
     </properties>
 
     <dependencies>

--- a/meta-model/pom.xml
+++ b/meta-model/pom.xml
@@ -40,7 +40,7 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit-jupiter.version>6.1.0</junit-jupiter.version>
+    <junit-jupiter.version>6.1.1</junit-jupiter.version>
   </properties>
   <modules>
     <module>model-security</module>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -117,8 +117,6 @@
         <selenium.version>4.45.0</selenium.version>
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
 
-        <junit-jupiter.version>6.1.1</junit-jupiter.version>
-        <junit-platform.version>6.1.0</junit-platform.version>
         <!-- 修复 plexus-utils 目录遍历漏洞 -->
         <plexus-utils.version>4.0.3</plexus-utils.version>
         <plexus-xml.version>4.1.1</plexus-xml.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -962,7 +962,7 @@
             <dependency>
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-core</artifactId>
-                <version>2.4.1.Final</version>
+                <version>2.4.2.Final</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -66,7 +66,7 @@
         <reactor.verion>3.8.6</reactor.verion>
         <protobuf-java.version>4.35.1</protobuf-java.version>
 
-        <tomcat-embed.version>11.0.22</tomcat-embed.version>
+        <tomcat-embed.version>11.0.23</tomcat-embed.version>
 
         <mysql-connector-j.version>9.7.0</mysql-connector-j.version>
         <postgresql.version>42.7.11</postgresql.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -51,7 +51,7 @@
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
-        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
 
         <deamond.version>0.1.4.9</deamond.version>
         

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -71,7 +71,7 @@
         <mysql-connector-j.version>9.7.0</mysql-connector-j.version>
         <postgresql.version>42.7.11</postgresql.version>
         <mybatis.version>3.5.19</mybatis.version>
-        <hibernate-orm.version>7.4.1.Final</hibernate-orm.version>
+        <hibernate-orm.version>7.4.2.Final</hibernate-orm.version>
         <seata.version>2.6.0</seata.version>
 
         <commons-lang3.version>3.20.0</commons-lang3.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -106,7 +106,7 @@
         <dubbo.version>3.3.6</dubbo.version>
         <nacos.version>3.2.2</nacos.version>
 
-        <lucense.version>10.4.0</lucense.version>
+        <lucense.version>10.5.0</lucense.version>
         <elasticsearch.version>9.4.2</elasticsearch.version>
 
         <flink.version>1.20.5</flink.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -769,7 +769,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -69,7 +69,7 @@
         <tomcat-embed.version>11.0.23</tomcat-embed.version>
 
         <mysql-connector-j.version>9.7.0</mysql-connector-j.version>
-        <postgresql.version>42.7.11</postgresql.version>
+        <postgresql.version>42.7.12</postgresql.version>
         <mybatis.version>3.5.19</mybatis.version>
         <hibernate-orm.version>7.4.3.Final</hibernate-orm.version>
         <seata.version>2.6.0</seata.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -71,7 +71,7 @@
         <mysql-connector-j.version>9.7.0</mysql-connector-j.version>
         <postgresql.version>42.7.11</postgresql.version>
         <mybatis.version>3.5.19</mybatis.version>
-        <hibernate-orm.version>7.4.2.Final</hibernate-orm.version>
+        <hibernate-orm.version>7.4.3.Final</hibernate-orm.version>
         <seata.version>2.6.0</seata.version>
 
         <commons-lang3.version>3.20.0</commons-lang3.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -58,7 +58,7 @@
         
         <acanx-utils.version>0.4.2</acanx-utils.version>
         <openjfx.version>26.0.1</openjfx.version>
-        <javassist.version>3.31.0-GA</javassist.version>
+        <javassist.version>3.32.0-GA</javassist.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <bytebuddy.version>1.18.10</bytebuddy.version>
 

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -114,7 +114,7 @@
 
         <micrometer.version>1.17.0</micrometer.version>
 
-        <selenium.version>4.44.0</selenium.version>
+        <selenium.version>4.45.0</selenium.version>
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
 
         <junit-jupiter.version>6.1.0</junit-jupiter.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -94,7 +94,7 @@
         <freemarker.version>2.3.34</freemarker.version>
         <jsoup.version>1.22.2</jsoup.version>
         <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
-        <redisson.version>4.6.0</redisson.version>
+        <redisson.version>4.6.1</redisson.version>
 
         <slf4j.version>2.0.18</slf4j.version>
         <jspecify.version>1.0.0</jspecify.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -762,7 +762,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.13</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -120,6 +120,8 @@
         <!-- 修复 plexus-utils 目录遍历漏洞 -->
         <plexus-utils.version>4.0.3</plexus-utils.version>
         <plexus-xml.version>4.1.1</plexus-xml.version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
+        <junit-platform.version>6.1.1</junit-platform.version>
     </properties>
 
 

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -1064,7 +1064,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.6.1</version>
+                <version>5.6.2</version>
             </dependency>
 
             <dependency>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -107,7 +107,7 @@
         <nacos.version>3.2.2</nacos.version>
 
         <lucense.version>10.5.0</lucense.version>
-        <elasticsearch.version>9.4.2</elasticsearch.version>
+        <elasticsearch.version>9.4.3</elasticsearch.version>
 
         <flink.version>1.20.5</flink.version>
         <hadoop.version>3.5.0</hadoop.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -93,7 +93,7 @@
         <caffeine.version>3.2.4</caffeine.version>
         <freemarker.version>2.3.34</freemarker.version>
         <jsoup.version>1.22.2</jsoup.version>
-        <hibernate-validator.version>9.1.0.Final</hibernate-validator.version>
+        <hibernate-validator.version>9.1.1.Final</hibernate-validator.version>
         <redisson.version>4.6.1</redisson.version>
 
         <slf4j.version>2.0.18</slf4j.version>

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -117,7 +117,7 @@
         <selenium.version>4.45.0</selenium.version>
         <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
 
-        <junit-jupiter.version>6.1.0</junit-jupiter.version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
         <junit-platform.version>6.1.0</junit-platform.version>
         <!-- 修复 plexus-utils 目录遍历漏洞 -->
         <plexus-utils.version>4.0.3</plexus-utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <jackson.version>2.22.0</jackson.version>
         <fastjson2.version>2.0.61</fastjson2.version>
         <lombok.version>1.18.46</lombok.version>
-        <junit-jupiter.version>6.1.0</junit-jupiter.version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
批量合并 Dependabot PR 后的依赖升级汇总（共 145 个 commits）。

## 主要依赖更新

### 核心框架
- hibernate-validator: 9.1.0.Final → 9.1.1.Final
- hibernate-core: 7.4.1.Final → 7.4.3.Final
- tomcat-embed-core: 11.0.22 → 11.0.23
- tomcat-annotations-api: 11.0.22 → 11.0.23
- spring-boot-admin: 4.1.0 → 4.1.1
- mybatis-spring: 4.0.0 → 4.1.0
- undertow-core: 2.4.1.Final → 2.4.2.Final

### SDK 与云服务
- awssdk.version: 2.46.11 → 2.46.21
- huaweicloud-sdk.version: 3.1.200 → 3.1.201
- oapi-sdk (飞书): 2.8.1 → 2.8.3
- alibabacloud-oss-v2: 0.4.1 → 0.5.0
- fc20230330: 4.7.6 → 4.7.7
- longport-openapi-sdk: 3.0.23 → 4.3.3
- tencentcloud-sdk-java-ses: 3.1.1482 → 3.1.1494
- cos_api: 5.6.269 → 5.6.271

### 日志与测试
- log4j: 2.26.0 → 2.26.1
- logback: 1.5.34 → 1.5.37
- junit-jupiter: 6.1.0 → 6.1.1
- junit-platform: 6.1.0 → 6.1.1

### 其他
- javassist: 3.31.0-GA → 3.32.0-GA
- commonmark: 0.28.0 → 0.29.0
- redisson: 4.6.0 → 4.6.1
- selenium-api: 4.44.0 → 4.45.0
- central-publishing-maven-plugin: 0.10.0 → 0.11.0
- grpc: 1.82.0 → 1.82.1
- httpclient5: 5.6.1 → 5.6.2
- httpcore5: 5.4.2 → 5.4.3
- lucene-core: 10.4.0 → 10.5.0
- elasticsearch: 9.4.2 → 9.4.3
- kafka: 4.3.0 → 4.3.1
- graal-sdk: 25.0.3 → 25.1.3
- native-maven-plugin: 1.1.2 → 1.1.3
- postgresql: 42.7.11 → 42.7.12
- bytebuddy: 1.18.10 → 1.18.11
- netty-tcnative-boringssl-static: 2.0.79.Final → 2.0.80.Final

## 修复的问题
- 修复 bom-aio 中 AWS SDK 版本不一致（2.46.17 → 2.46.21）
- 修复 bom-aio 中华为云 SDK 版本不一致（3.1.202 → 3.1.201）
- 恢复 meta-bom/pom.xml 中被删除但仍在引用的属性
- 恢复 os-dependencies/pom.xml 中被删除的 junit 版本属性

## 注意事项
- longport-openapi-sdk 从 3.0.23 升级到 4.3.3（major 版本跳跃），需确认兼容性
- 所有 PR 编译检查均已通过