### PR TITLE
fix: 修复 PR #2000 review 发现的问题

### DIFF
--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -2399,13 +2399,13 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>ses</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
@@ -2571,7 +2571,7 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-functiongraph</artifactId>
-        <version>3.1.202</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.google.cloud.functions</groupId>
@@ -2627,12 +2627,12 @@
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-core</artifactId>
-        <version>3.1.202</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.huaweicloud.sdk</groupId>
         <artifactId>huaweicloud-sdk-apig</artifactId>
-        <version>3.1.202</version>
+        <version>3.1.201</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>
@@ -2666,59 +2666,59 @@
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>lambda</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>cloudwatch</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>costexplorer</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sqs</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sns</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>scheduler</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
         <scope>compile</scope>
       </dependency>
         <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>2.46.17</version>
+        <version>2.46.21</version>
       </dependency>
         <dependency>
         <groupId>com.aliyun</groupId>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -217,6 +217,8 @@
         <httpclient.version>4.5.14</httpclient.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <httpasyncclient.version>4.1.5</httpasyncclient.version>
+        <httpclient5.version>5.6.2</httpclient5.version>
+        <httpcore5.version>5.4.3</httpcore5.version>
         <jsoup.version>1.22.2</jsoup.version>
 
         <snakeyaml.version>2.7</snakeyaml.version>
@@ -277,6 +279,8 @@
         <!--  日志依赖  -->
 
         <junit-vintage-engine.version>6.1.1</junit-vintage-engine.version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
+        <junit-platform.version>6.1.1</junit-platform.version>
         <junit.version>4.13.2</junit.version>
 
         <!-- Spring Data 版本 -->

--- a/os-dependencies/pom.xml
+++ b/os-dependencies/pom.xml
@@ -120,6 +120,8 @@
         <!-- 修复 plexus-utils 目录遍历漏洞 -->
         <plexus-utils.version>4.0.3</plexus-utils.version>
         <plexus-xml.version>4.1.1</plexus-xml.version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
+        <junit-platform.version>6.1.1</junit-platform.version>
     </properties>
 
 


### PR DESCRIPTION
修复以下问题：

1. **修复 bom-aio 版本不一致** — AWS SDK 2.46.17 → 2.46.21，华为云 SDK 3.1.202 → 3.1.201
2. **恢复被删除但仍在引用的属性** — meta-bom/pom.xml 恢复 httpclient5.version、httpcore5.version、junit-jupiter.version、junit-platform.version
3. **恢复 os-dependencies 的 junit 版本属性** — 添加 junit-jupiter.version 和 junit-platform.version

关联 PR: #2000