### PR TITLE
chore(deps): bump awssdk.version from 2.46.21 to 2.47.0

### DIFF
--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -265,7 +265,7 @@
         <selenium-devtools.version>4.41.0</selenium-devtools.version>
         <selenium-htmlunit.version>4.29.0</selenium-htmlunit.version>
 
-        <awssdk.version>2.46.21</awssdk.version>
+        <awssdk.version>2.47.0</awssdk.version>
         <huaweicloud-sdk.version>3.1.204</huaweicloud-sdk.version>
 
         <!-- 日志依赖  -->


### PR DESCRIPTION
替代 #2113 #2116 #2120（三个 dependabot PR 互相冲突，改为手动统一升级）