### PR TITLE
fix(bom-aio): 删除 netty 系列重复依赖条目，修复 flatten 构建失败

### DIFF
--- a/meta-bom/bom-aio/pom.xml
+++ b/meta-bom/bom-aio/pom.xml
@@ -1429,41 +1429,6 @@
       </dependency>
         <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-codec-protobuf</artifactId>
-        <version>4.2.17.Final</version>
-      </dependency>
-        <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-marshalling</artifactId>
-        <version>4.2.17.Final</version>
-      </dependency>
-        <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-common</artifactId>
-        <version>4.2.17.Final</version>
-      </dependency>
-        <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-dev-tools</artifactId>
-        <version>4.2.17.Final</version>
-      </dependency>
-        <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
-        <version>4.2.17.Final</version>
-      </dependency>
-        <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler-proxy</artifactId>
-        <version>4.2.17.Final</version>
-      </dependency>
-        <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler-ssl-ocsp</artifactId>
-        <version>4.2.17.Final</version>
-      </dependency>
-        <dependency>
-        <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
         <version>4.2.17.Final</version>
       </dependency>


### PR DESCRIPTION
## 问题
`dependa` 分支构建自 08-10 起持续失败，根因：`meta-bom/bom-aio/pom.xml` 中 netty 系列依赖重复（netty-codec-protobuf/marshalling/common/dev-tools/handler/handler-proxy/handler-ssl-ocsp 各出现 2 次，均为 4.2.17.Final），flatten-maven-plugin 报 `Duplicate dependency`。

## 修复
删除第二份重复的 6 个 netty 依赖条目（-35 行），保留第一份完整列表。

## 验证
- 修复后 GAV 完全重复检查：无
- XML 解析合法

Closes #2439 的遗留问题