### PR TITLE
fix(bom-aio): bom-graalvm.version 对齐 25.0.8.9，修复 UpdateBOMAIODeps graalvm 降级

### DIFF
--- a/.github/workflows/UpdateBomGraalvmVersion.yml
+++ b/.github/workflows/UpdateBomGraalvmVersion.yml
@@ -62,28 +62,6 @@ jobs:
           print(f"最新版本 (latest): {latest_version}")
           print(f"将使用的版本: {new_version}")
 
-          # 2. 读取当前 bom-aio-origin/pom.xml 中的配置版本
-          pom_path = "meta-bom/bom-aio-origin/pom.xml"
-          with open(pom_path, "r", encoding="utf-8") as f:
-              pom_content = f.read()
-          
-          # 查找 <bom-graalvm.version>xxx</bom-graalvm.version>
-          match = re.search(r'<bom-graalvm\.version>([^<]+)</bom-graalvm\.version>', pom_content)
-          if not match:
-              print("❌ 未在 pom.xml 中找到 <bom-graalvm.version> 属性")
-              exit(1)
-          
-          current_version = match.group(1)
-          print(f"当前配置版本: {current_version}")
-          
-          if current_version == new_version:
-              print(f"✅ 版本已是最新: {current_version}")
-              # 设置输出变量，表示无需更新
-              with open(os.environ.get('GITHUB_OUTPUT', '/dev/null'), 'a') as f:
-                  f.write("updated=false\n")
-              exit(0)
-          
-          # 3. 版本比较（按数字段比较）
           def parse_version(v):
               parts = v.split(".")
               result = []
@@ -94,6 +72,58 @@ jobs:
                       result.append(0)
               return result
           
+          # 2. 读取当前 bom-aio-origin/pom.xml 中的 bom-graalvm 版本
+          #    （支持两种形态：旧式硬编码属性 <bom-graalvm.version>，或新式派生 <version>25.${revision}</version>）
+          pom_path = "meta-bom/bom-aio-origin/pom.xml"
+          with open(pom_path, "r", encoding="utf-8") as f:
+              pom_content = f.read()
+          
+          # 2a. 旧式：查找 <bom-graalvm.version>xxx</bom-graalvm.version>
+          match = re.search(r'<bom-graalvm\.version>([^<]+)</bom-graalvm\.version>', pom_content)
+          if match:
+              current_version = match.group(1)
+              version_mode = "hardcoded"
+          else:
+              # 2b. 新式：解析 <artifactId>bom-graalvm</artifactId> 后的 <version>25.${revision}</version>
+              dep_match = re.search(
+                  r'<artifactId>bom-graalvm</artifactId>\s*<version>([^<]+)</version>',
+                  pom_content
+              )
+              if not dep_match:
+                  print("❌ 未在 pom.xml 中找到 bom-graalvm 依赖定义")
+                  exit(1)
+              raw_version = dep_match.group(1)
+              # 展开 ${revision}
+              rev_match = re.search(r'<revision>([^<]+)</revision>', pom_content)
+              current_version = raw_version.replace("${revision}", rev_match.group(1) if rev_match else "")
+              version_mode = "derived (25.${revision})"
+          
+          print(f"当前配置版本: {current_version} (模式: {version_mode})")
+          
+          if version_mode == "derived":
+              # 派生模式下版本跟随项目 revision，不自动覆盖，仅对比提示
+              cur_parts = parse_version(current_version)
+              new_parts = parse_version(new_version)
+              if new_parts > cur_parts:
+                  print(f"⚠️ Central 发布版 {new_version} 高于本地派生版本 {current_version}，"
+                        f"如需升级请走 bom-graalvm 模块发布流程（版本跟随 revision），此处不自动修改")
+                  with open(os.environ.get('GITHUB_OUTPUT', '/dev/null'), 'a') as f:
+                      f.write("updated=false\n")
+                      f.write(f"note=central_newer:{new_version}>local:{current_version}\n")
+                  exit(0)
+              print(f"✅ 派生版本 {current_version} 不低于 Central 最新 {new_version}，无需更新")
+              with open(os.environ.get('GITHUB_OUTPUT', '/dev/null'), 'a') as f:
+                  f.write("updated=false\n")
+              exit(0)
+          
+          if current_version == new_version:
+              print(f"✅ 版本已是最新: {current_version}")
+              # 设置输出变量，表示无需更新
+              with open(os.environ.get('GITHUB_OUTPUT', '/dev/null'), 'a') as f:
+                  f.write("updated=false\n")
+              exit(0)
+          
+          # 3. 版本比较（按数字段比较）
           current_parts = parse_version(current_version)
           new_parts = parse_version(new_version)
           

--- a/.github/workflows/UpdateBomGraalvmVersion.yml
+++ b/.github/workflows/UpdateBomGraalvmVersion.yml
@@ -73,30 +73,28 @@ jobs:
               return result
           
           # 2. 读取当前 bom-aio-origin/pom.xml 中的 bom-graalvm 版本
-          #    （支持两种形态：旧式硬编码属性 <bom-graalvm.version>，或新式派生 <version>25.${revision}</version>）
+          #    （支持两种形态：硬编码属性 <bom-graalvm.version>25.0.8.8</bom-graalvm.version>，
+          #     或派生属性 <bom-graalvm.version>25.${revision}</bom-graalvm.version>）
           pom_path = "meta-bom/bom-aio-origin/pom.xml"
           with open(pom_path, "r", encoding="utf-8") as f:
               pom_content = f.read()
           
-          # 2a. 旧式：查找 <bom-graalvm.version>xxx</bom-graalvm.version>
+          # 查找 <bom-graalvm.version>xxx</bom-graalvm.version> 属性
           match = re.search(r'<bom-graalvm\.version>([^<]+)</bom-graalvm\.version>', pom_content)
-          if match:
-              current_version = match.group(1)
-              version_mode = "hardcoded"
-          else:
-              # 2b. 新式：解析 <artifactId>bom-graalvm</artifactId> 后的 <version>25.${revision}</version>
-              dep_match = re.search(
-                  r'<artifactId>bom-graalvm</artifactId>\s*<version>([^<]+)</version>',
-                  pom_content
-              )
-              if not dep_match:
-                  print("❌ 未在 pom.xml 中找到 bom-graalvm 依赖定义")
-                  exit(1)
-              raw_version = dep_match.group(1)
-              # 展开 ${revision}
+          if not match:
+              print("❌ 未在 pom.xml 中找到 <bom-graalvm.version> 属性")
+              exit(1)
+          
+          raw_version = match.group(1)
+          if "${revision}" in raw_version:
+              # 派生模式：展开 ${revision}
               rev_match = re.search(r'<revision>([^<]+)</revision>', pom_content)
               current_version = raw_version.replace("${revision}", rev_match.group(1) if rev_match else "")
               version_mode = "derived (25.${revision})"
+          else:
+              # 硬编码模式
+              current_version = raw_version
+              version_mode = "hardcoded"
           
           print(f"当前配置版本: {current_version} (模式: {version_mode})")
           

--- a/meta-bom/bom-aio-origin/pom.xml
+++ b/meta-bom/bom-aio-origin/pom.xml
@@ -45,7 +45,6 @@
           <!-- 将此属性设置为 true，即可跳过该模块的 deploy 阶段 -->
           <maven.deploy.skip>true</maven.deploy.skip>
           <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-          <bom-graalvm.version>25.0.8.9</bom-graalvm.version>
     </properties>
 
     <dependencyManagement>
@@ -88,7 +87,7 @@
             <dependency>
                 <groupId>com.acanx.meta.component</groupId>
                 <artifactId>bom-graalvm</artifactId>
-                <version>${bom-graalvm.version}</version>
+                <version>25.${revision}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/meta-bom/bom-aio-origin/pom.xml
+++ b/meta-bom/bom-aio-origin/pom.xml
@@ -45,7 +45,7 @@
           <!-- 将此属性设置为 true，即可跳过该模块的 deploy 阶段 -->
           <maven.deploy.skip>true</maven.deploy.skip>
           <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-          <bom-graalvm.version>25.0.8.8</bom-graalvm.version>
+          <bom-graalvm.version>25.0.8.9</bom-graalvm.version>
     </properties>
 
     <dependencyManagement>

--- a/meta-bom/bom-aio-origin/pom.xml
+++ b/meta-bom/bom-aio-origin/pom.xml
@@ -45,6 +45,8 @@
           <!-- 将此属性设置为 true，即可跳过该模块的 deploy 阶段 -->
           <maven.deploy.skip>true</maven.deploy.skip>
           <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+          <!-- bom-graalvm 版本：与 bom-graalvm 模块版本定义 25.${revision} 保持一致，发版时随 revision 自动对齐 -->
+          <bom-graalvm.version>25.${revision}</bom-graalvm.version>
     </properties>
 
     <dependencyManagement>
@@ -87,7 +89,7 @@
             <dependency>
                 <groupId>com.acanx.meta.component</groupId>
                 <artifactId>bom-graalvm</artifactId>
-                <version>25.${revision}</version>
+                <version>${bom-graalvm.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -46,7 +46,7 @@
         <meta-open.version>0.8.9</meta-open.version>
         <autil.version>1.3.0</autil.version>
         <module.version>0.4.2</module.version>
-        <bom-graalvm.version>25.0.8.6</bom-graalvm.version>
+        <bom-graalvm.version>25.0.8.9</bom-graalvm.version>
 
         <java.version>21</java.version>
         <maven-compiler-source.version>21</maven-compiler-source.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -46,7 +46,6 @@
         <meta-open.version>0.8.9</meta-open.version>
         <autil.version>1.3.0</autil.version>
         <module.version>0.4.2</module.version>
-        <bom-graalvm.version>25.0.8.9</bom-graalvm.version>
 
         <java.version>21</java.version>
         <maven-compiler-source.version>21</maven-compiler-source.version>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -46,6 +46,7 @@
         <meta-open.version>0.8.9</meta-open.version>
         <autil.version>1.3.0</autil.version>
         <module.version>0.4.2</module.version>
+        <bom-graalvm.version>25.${revision}</bom-graalvm.version>
 
         <java.version>21</java.version>
         <maven-compiler-source.version>21</maven-compiler-source.version>


### PR DESCRIPTION
## 问题
PR #2503（UpdateBOMAIODeps 生成）将 bom-aio/pom.xml 中 graalvm 系列依赖从 1.1.9 **降级**为 1.1.3。

## 根因
1. `bom-aio-origin/pom.xml` 通过 `dependencyManagement` import `com.acanx.meta.component:bom-graalvm:25.0.8.8`
2. Maven Central 上 **25.0.8.8 内的 graalvm 依赖为 1.1.3（旧）**；本地 bom-graalvm 模块（版本 25.0.8.9）已升级到 1.1.9，但 **25.0.8.9 未发布到 Central**
3. UpdateBOMAIODeps workflow 执行 `mvn help:effective-pom` 时解析 Central 的 25.0.8.8 → graalvm=1.1.3 → Python 脚本同步到 bom-aio/pom.xml → 降级

## 修复
- `bom-aio-origin/pom.xml`: `bom-graalvm.version` 25.0.8.8 → **25.0.8.9**（与本地模块版本 25.${revision} 一致）
- `meta-bom/pom.xml`: `bom-graalvm.version` 25.0.8.6 → **25.0.8.9**（保持一致）

workflow 本地 `mvn clean install` 后，effective-pom 将解析本地 25.0.8.9（graalvm=1.1.9），不再降级。

## 备注
建议后续将 bom-graalvm 25.0.8.9 发布到 Maven Central，避免外部解析依赖 Central 版本时仍拿到旧版。