### PR TITLE
fix(bom-aio): bom-graalvm.version 由 UpdateProjectVersion 程序派生替换（25.<revision>）

### DIFF
--- a/.github/Python/UpdatMeavenProperties.py
+++ b/.github/Python/UpdatMeavenProperties.py
@@ -2,11 +2,20 @@
 """
 Update specified Maven properties in a pom.xml file using targeted regex replacement.
 Preserves all comments, formatting, and whitespace.
+
+Supports derived properties: a property can be mapped to a prefixed version of
+new_version, e.g. bom-graalvm.version = 25.<new_version>.
 """
 
 import argparse
 import re
 import sys
+
+# 派生属性映射：属性名 -> 版本前缀（替换时实际值 = 前缀 + new_version）
+# bom-graalvm 模块版本定义为 25.${revision}，因此引用方的版本号必须同步为 25.<revision>
+DERIVED_PREFIX = {
+    "bom-graalvm.version": "25.",
+}
 
 def update_properties(pom_path, new_version, properties):
     """Replace property values inside the <properties> block only."""
@@ -27,12 +36,14 @@ def update_properties(pom_path, new_version, properties):
 
     updated = False
     for prop in properties:
+        prefix = DERIVED_PREFIX.get(prop, "")
+        actual_value = f"{prefix}{new_version}"
         # 匹配 <prop>旧值</prop>，其中旧值不含 '<' 字符（避免嵌套标签干扰）
         pattern = re.compile(rf'(<{re.escape(prop)}>)[^<]*(</{re.escape(prop)}>)')
-        new_block, count = pattern.subn(rf'\g<1>{new_version}\g<2>', prop_block)
+        new_block, count = pattern.subn(rf'\g<1>{actual_value}\g<2>', prop_block)
         if count > 0:
             prop_block = new_block
-            print(f"  ✅ Updated {prop} = {new_version}")
+            print(f"  ✅ Updated {prop} = {actual_value}")
             updated = True
         else:
             print(f"  ⚠️  Property '{prop}' not found in properties section, skipping.")

--- a/.github/workflows/UpdateProjectVersion.yml
+++ b/.github/workflows/UpdateProjectVersion.yml
@@ -43,7 +43,8 @@ jobs:
           NEW_VERSION: ${{ steps.version.outputs.new_version }}
         run: |
           # 要更新的属性列表
-          PROPERTIES=("revision" "meta-open.version" "meta.version")
+          # 注意：bom-graalvm.version 为派生属性（值 = 25.<new_version>），由 UpdatMeavenProperties.py 自动加前缀
+          PROPERTIES=("revision" "meta-open.version" "meta.version" "bom-graalvm.version")
           # 需要处理的目录（包含 pom.xml）
           DIRS=("." "./os-dependencies" "./meta-bom" "./meta-bom/bom-aio-origin")
           for dir in "${DIRS[@]}"; do
@@ -72,5 +73,5 @@ jobs:
           title: "chore(version): Update project version to ${{ steps.version.outputs.new_version }}"
           body: |
             This PR updates the Maven properties to version `${{ steps.version.outputs.new_version }}`.
-            Properties updated: `revision`, `meta-open.version`, `meta.version`.
+            Properties updated: `revision`, `meta-open.version`, `meta.version`, `bom-graalvm.version` (derived: 25.<version>).
           base: dev   # 根据你的默认分支修改

--- a/meta-bom/bom-aio-origin/pom.xml
+++ b/meta-bom/bom-aio-origin/pom.xml
@@ -45,8 +45,8 @@
           <!-- 将此属性设置为 true，即可跳过该模块的 deploy 阶段 -->
           <maven.deploy.skip>true</maven.deploy.skip>
           <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-          <!-- bom-graalvm 版本：与 bom-graalvm 模块版本定义 25.${revision} 保持一致，发版时随 revision 自动对齐 -->
-          <bom-graalvm.version>25.${revision}</bom-graalvm.version>
+          <!-- bom-graalvm 版本：派生自 revision（=25.<revision>），由 UpdateProjectVersion 发版时自动替换 -->
+          <bom-graalvm.version>25.0.8.9</bom-graalvm.version>
     </properties>
 
     <dependencyManagement>

--- a/meta-bom/pom.xml
+++ b/meta-bom/pom.xml
@@ -46,7 +46,7 @@
         <meta-open.version>0.8.9</meta-open.version>
         <autil.version>1.3.0</autil.version>
         <module.version>0.4.2</module.version>
-        <bom-graalvm.version>25.${revision}</bom-graalvm.version>
+        <bom-graalvm.version>25.0.8.9</bom-graalvm.version>
 
         <java.version>21</java.version>
         <maven-compiler-source.version>21</maven-compiler-source.version>


### PR DESCRIPTION
## 背景
PR #2504 已合并（`bom-graalvm.version` = `25.${revision}` 嵌套占位符写法）。经评估，嵌套属性占位符存在编译/工具解析风险，且不符合"统一版本管理、程序强制替换"原则，改为**硬编码 + 程序替换**方案。

## 方案
| 文件 | 变更 |
|------|------|
| `bom-aio-origin/pom.xml` | `bom-graalvm.version` = 硬编码 **25.0.8.9**（当前值，发版时由程序替换） |
| `meta-bom/pom.xml` | `bom-graalvm.version` = 硬编码 **25.0.8.9** |
| `.github/Python/UpdatMeavenProperties.py` | 新增 `DERIVED_PREFIX` 派生属性映射：`bom-graalvm.version` 实际值 = `25.<new_version>` |
| `.github/workflows/UpdateProjectVersion.yml` | PROPERTIES 列表加入 `bom-graalvm.version` |

## 发版行为（已验证）
`UpdateProjectVersion` 触发 → `revision` 0.8.9→0.8.10 时，`bom-graalvm.version` 被程序替换为 **25.0.8.10**（与 bom-graalvm 模块 `25.${revision}` 对齐）✅

已验证模拟：脚本对 0.8.10 的替换输出正确（revision=0.8.10, bom-graalvm.version=25.0.8.10）。

## 效果
- 无嵌套占位符，无编译风险
- 发版零手动维护，版本号统一由 UpdateProjectVersion 管理
- 解决 UpdateBOMAIODeps 生成 graalvm 降级问题（#2503 验证过）