### PR TITLE
docs(release): 新增发版前/后检查清单，首次合并触发问题独立成文

### DIFF
--- a/Docs/Release/PostRelease-Checklist.md
+++ b/Docs/Release/PostRelease-Checklist.md
@@ -1,0 +1,58 @@
+# MetaOpen 发版后收尾/后置工作清单（Post-Release Checklist）
+
+> 适用于正式版本发布（dev→main 合并 + ReleaseWorkflow 触发）完成后执行，确认发布结果并处理后续事项。
+>
+> 关联文档：[README.md](./README.md)（发布方案总览）、[PreRelease-Checklist.md](./PreRelease-Checklist.md)（发版前检查）
+> 最后更新：2026-08-19
+
+---
+
+## 1. 发布结果确认
+
+- [ ] `ReleaseWorkflow` 已触发且 **success**（Actions 页面确认 `event=push`）
+- [ ] Tag 已创建：`git ls-remote --tags origin | grep V<version>`（如 `V0.8.9`，annotated tag）
+- [ ] GitHub Release 已创建：`gh release list --repo ACANX/MetaOpen`
+- [ ] Release 内容正确（版本号、changelog 自动生成、无错误资产）
+
+## 2. Maven Central 发布（可选但通常需要）
+
+- [ ] 触发 `ReleaseFullArtifactsByBatch` workflow（手动）
+- [ ] 确认各模块 deploy **success**（os-dependencies / meta-model / meta-bom 等）
+- [ ] 验证 Central 制品可用：
+      `curl -s "https://repo1.maven.org/maven2/com/acanx/meta/<artifact>/<version>/" | grep <version>`
+- [ ] 确认 bom-graalvm `25.<version>` 已发布（供外部依赖解析）
+- [ ] 确认 bom-aio `<version>` 已发布且为自包含展开版（无 import 依赖）
+
+## 3. 安全警报与依赖
+
+- [ ] Dependabot 安全警报随 main 更新自动关闭（指向旧版本的警报应变为 fixed）
+- [ ] 如警报未自动关闭，检查是否仍指向旧版本（可能需要手动确认/重扫）
+
+## 4. 分支与后续版本准备
+
+- [ ] 确认 main 已包含发布版本的全部代码（`git log origin/main --oneline -3`）
+- [ ] 如发布流程包含版本递增，确认下一版本号规划（如 0.8.10 或 0.9.0）
+- [ ] （可选）dev 分支已准备好继续开发（新特性分支基于最新 dev）
+
+## 5. 文档与记录
+
+- [ ] `Docs/Release/README.md` 的「版本演进历史」已更新（新增本次版本行）
+- [ ] 发布相关 ISSUE 已更新状态（如 SonarCloud 问题 #2507 若有进展）
+- [ ] （可选）在发布群/通知渠道同步发布结果
+
+## 6. 已知遗留事项跟踪
+
+- [ ] SonarCloudCodeAnalysis 失败问题（issue #2507）是否已解决；如未解决，确认不阻塞
+- [ ] 记录本次发布中发现的任何新问题到 ISSUE 跟踪
+
+---
+
+## 异常处理速查
+
+| 场景 | 处理方式 |
+|------|---------|
+| ReleaseWorkflow 未触发 | 检查 Actions 页面；手动触发：`gh workflow run ReleaseWorkflow.yml --repo ACANX/MetaOpen --ref main` |
+| Tag 已存在（幂等跳过） | 确认 tag 指向正确提交；如需重建：删除后重新触发 |
+| Release 内容错误 | `gh release edit V<version> --repo ACANX/MetaOpen` 修正 |
+| Maven 发布失败 | 查看 workflow 日志；常见为凭据/GPG 问题；修复后重新触发 |
+| 安全警报未关闭 | 检查依赖版本是否真的修复；必要时手动 dismiss 并注明原因 |

--- a/Docs/Release/PreRelease-Checklist.md
+++ b/Docs/Release/PreRelease-Checklist.md
@@ -1,0 +1,68 @@
+# MetaOpen 正式发版前检查清单（Pre-Release Checklist）
+
+> 适用于每次正式版本（如 0.8.9）发布前执行。按顺序逐项确认，全部通过后方可发起 dev→main 合并。
+>
+> 关联文档：[README.md](./README.md)（发布方案总览）、[PostRelease-Checklist.md](./PostRelease-Checklist.md)（发版后收尾）
+> 最后更新：2026-08-19
+
+---
+
+## 1. 版本号检查
+
+- [ ] 根 `pom.xml` 的 `<revision>` 为待发布版本（如 `0.8.9`）
+- [ ] `version` 文件内容与 `<revision>` 一致
+- [ ] `meta-open.version` / `meta.version` 等子版本属性已同步（`UpdateProjectVersion` 已执行）
+- [ ] `bom-aio-origin/pom.xml` 的 `bom-graalvm.version` 为 `25.<revision>`（如 `25.0.8.9`）
+- [ ] `meta-bom/pom.xml` 的 `bom-graalvm.version` 与上述一致
+- [ ] 全仓库搜索无旧版本号残留（如发布 0.8.9 时无遗漏的 0.8.8 引用）
+
+## 2. 分支与 PR 状态
+
+- [ ] 目标发布分支（dev）无未合并的 open PR（或已确认可推迟）
+- [ ] dev 分支领先 main 的提交均为预期内容（`git log origin/main..origin/dev --oneline`）
+- [ ] ReleaseWorkflow（`.github/workflows/ReleaseWorkflow.yml`）已存在于 dev 分支
+- [ ] 发布方案文档（Docs/Release/）已更新至当前版本
+
+## 3. CI 与构建验证
+
+- [ ] `MultiMavenJDKBranchCI` 在 dev 最新提交上 **success**（JDK17/21/25 × 平台矩阵）
+- [ ] `SonarQube`（自建）分析 **success**
+- [ ] `CodeQLAdvanced` 安全扫描 **success**
+- [ ] `UpdateBOMAIODeps` 执行后无异常（bom-aio 依赖同步正常，无版本降级）
+- [ ] `Automatic Dependency Submission` **success**
+- [ ] SonarCloudCodeAnalysis：确认失败原因已知（当前为 SONAR_TOKEN 授权问题，见 issue #2507）；若为质量门禁硬性要求，需先修复
+
+## 4. 依赖与安全
+
+- [ ] Dependabot 安全警报中，目标版本（main 合并后）对应的依赖均为修复版本
+      （当前涉及：httpclient5 ≥5.6.3、netty ≥4.2.16.Final、jsoup ≥1.23.1）
+- [ ] 无未处理的 CRITICAL/HIGH 级别安全警报
+
+## 5. 发布流程准备
+
+- [ ] 已确认 ReleaseWorkflow 触发方式（push 到 main 自动触发，首次合并即可触发，见 [WorkflowTrigger-Analysis.md](./WorkflowTrigger-Analysis.md)）
+- [ ] 已确认 main 分支无同名 tag（如 `V0.8.9`）已存在
+- [ ] （可选）已准备 Release 备注要点 / 已知变更清单
+- [ ] （可选）已确认 Maven Central 发布凭据（OSSRH/GPG）有效，如需本次发布制品
+
+## 6. 最终确认
+
+- [ ] 以上全部通过
+- [ ] 已获得发布决策人（ACANX）放行确认
+
+---
+
+## 执行入口
+
+全部检查通过后，执行发布：
+
+```bash
+# dev → main 合并 PR
+gh pr create --repo ACANX/MetaOpen --base main --head dev \
+  --title "Release 0.8.9: sync dev → main" \
+  --body "正式发布 0.8.9，合并后 ReleaseWorkflow 自动打 tag 并创建 Release"
+
+# 合并后 → 转 PostRelease-Checklist.md 执行收尾
+```
+
+> 提示：合并后到 Actions 页面确认 ReleaseWorkflow 已自动触发；若未触发，参见 [WorkflowTrigger-Analysis.md](./WorkflowTrigger-Analysis.md) 第 5.3 节手动兜底。

--- a/Docs/Release/README.md
+++ b/Docs/Release/README.md
@@ -126,23 +126,11 @@ on:
 
 **权限要求**：`permissions: contents: write`（用于推送 tag 和创建 Release）。
 
-### 3.3 首次合并触发问题（重要）
+### 3.3 首次合并触发问题
 
-**问题**：ReleaseWorkflow 文件首次进入 main 分支（即第一次 dev→main 合并）时，workflow 尚未存在于默认分支，`push` 事件能否触发？
+首次 dev→main 合并（ReleaseWorkflow 文件随该次 push 首次进入 main）时，`push` 事件**可以正常触发** workflow，无需等待下一个版本。
 
-**答案：能触发，无需等待下一个版本。**
-
-**原理**：GitHub Actions 的 `push: branches: [main]` 事件在分支被推送时，读取的是 **push 完成后的分支状态**。如果该次 push 恰好包含新增的 workflow 文件，该 push 本身就会触发新 workflow（GitHub 会在 push 后扫描 `.github/workflows/` 目录）。
-
-**实测验证**（2026-08-19，fork 环境）：
-
-| 事件 | 触发方式 | 结果 |
-|------|---------|------|
-| 第一次 push ReleaseWorkflow.yml 到 fork main | `push` 自动触发 | ✅ 自动执行，创建了 tag + Release |
-| 第二次 push（版本改为 0.8.9） | `push` 自动触发 | ✅ 自动执行，创建了 V0.8.9 tag + Release |
-| dry-run 验证 | `workflow_dispatch` | ✅ 幂等保护正确跳过已存在 tag |
-
-**注意**：`workflow_dispatch` 手动触发需要 workflow 已存在于默认分支（GitHub 平台限制），因此**首次合并前无法在 UI 手动触发**——但 `push` 自动触发不受此限制，这正是 release 流程依赖 `push` 事件的原因。
+详细探究（原理、实测验证、边界情况）见独立文档：**[WorkflowTrigger-Analysis.md](./WorkflowTrigger-Analysis.md)**。
 
 ---
 
@@ -173,9 +161,19 @@ gh release create V0.8.9 --generate-notes --repo ACANX/MetaOpen
 
 ---
 
-## 6. 验证记录
+## 6. 发布检查清单与配套文档
 
-### 6.1 ReleaseWorkflow 实验验证（fork: abcnx/MetaOpen）
+| 文档 | 用途 |
+|------|------|
+| **[PreRelease-Checklist.md](./PreRelease-Checklist.md)** | 正式发版前检查工作清单（版本号/分支/CI/安全/流程） |
+| **[PostRelease-Checklist.md](./PostRelease-Checklist.md)** | 发版后收尾/后置工作事项清单（结果确认/Central 发布/警报/文档） |
+| **[WorkflowTrigger-Analysis.md](./WorkflowTrigger-Analysis.md)** | 首次合并触发 ReleaseWorkflow 问题深入探究 |
+
+---
+
+## 7. 验证记录
+
+### 7.1 ReleaseWorkflow 实验验证（fork: abcnx/MetaOpen）
 
 | 验证项 | 结果 |
 |--------|------|
@@ -186,7 +184,7 @@ gh release create V0.8.9 --generate-notes --repo ACANX/MetaOpen
 | push 首次触发 | ✅ workflow 文件随 push 进入 main 时自动触发 |
 | 实验清理 | ✅ 测试 tag/Release 已删除，fork 恢复原状 |
 
-### 6.2 版本对齐验证（UpdateProjectVersion + bom-graalvm）
+### 7.2 版本对齐验证（UpdateProjectVersion + bom-graalvm）
 
 | 验证项 | 结果 |
 |--------|------|

--- a/Docs/Release/WorkflowTrigger-Analysis.md
+++ b/Docs/Release/WorkflowTrigger-Analysis.md
@@ -1,0 +1,94 @@
+# 首次合并触发 ReleaseWorkflow 问题探究
+
+> **主题**：ReleaseWorkflow 文件首次进入 main 分支（即第一次 dev→main 合并）时，`push` 事件能否触发该 workflow？
+>
+> 关联文档：[README.md](./README.md)（发布方案总览）
+> 最后更新：2026-08-19
+
+---
+
+## 1. 问题背景
+
+ReleaseWorkflow（`.github/workflows/ReleaseWorkflow.yml`）通过 `on: push: branches: [main]` 触发。它由 PR 合入 **dev** 分支，再随 dev→main 合并进入 **main**（默认分支）。
+
+由此产生一个疑问：**第一次 dev→main 合并时，workflow 文件才刚刚进入 main，`push` 事件是否会被 GitHub 识别并触发？还是必须等到下一次发版（文件已在 main 上）才会触发？**
+
+---
+
+## 2. 结论（先给答案）
+
+> ✅ **能触发，无需等待下一个版本。**
+>
+> 第一次 dev→main 合并（workflow 文件随该次 push 首次进入 main）时，`push` 事件会立即触发 ReleaseWorkflow。
+
+---
+
+## 3. 原理分析
+
+### 3.1 GitHub Actions 的 push 事件语义
+
+`push: branches: [main]` 的触发判定，基于**该次 push 完成之后的分支状态**：
+
+1. 开发者推送提交到 main
+2. GitHub 接收 push，更新 main 分支引用
+3. GitHub **重新扫描** main 分支上的 `.github/workflows/` 目录
+4. 若发现匹配的 workflow 文件（包括**本次 push 刚新增的**），触发对应 workflow
+
+即：GitHub 不是"用 push 之前的分支状态"判断，而是"用 push 之后的分支状态"判断。因此 workflow 文件随 push 首次出现时，该 push 本身就会触发它。
+
+### 3.2 与 workflow_dispatch 的区别（重要）
+
+| 触发方式 | 是否要求 workflow 已存在于默认分支 | 说明 |
+|----------|-----------------------------------|------|
+| `push` | ❌ 不要求 | 只要 push 后分支上有该文件即可触发 |
+| `workflow_dispatch` | ✅ **要求** | 手动触发前，GitHub 需先在默认分支发现该 workflow，否则 API 返回 404 |
+
+**推论**：ReleaseWorkflow 首次合入 main 之前，无法在 GitHub UI/API 手动触发它（`gh workflow run` 会 404）——这是平台限制。但发布流程依赖 `push` 事件自动触发，**不受此限制**。
+
+---
+
+## 4. 实测验证（fork 环境，2026-08-19）
+
+在 `abcnx/MetaOpen` fork 上进行了完整实验（上游 ACANX/MetaOpen 零风险）：
+
+| 事件 | 触发方式 | 结果 |
+|------|---------|------|
+| 第一次 push ReleaseWorkflow.yml 到 fork main | `push` 自动触发 | ✅ 自动执行，提取版本 0.8.8 → 创建了 tag V0.8.8 + Release |
+| 第二次 push（pom.xml 版本改为 0.8.9） | `push` 自动触发 | ✅ 自动执行，创建了 tag V0.8.9 + Release |
+| dry-run 验证（workflow_dispatch） | 手动触发 | ✅ 幂等保护正确跳过已存在 tag |
+
+**关键证据**：fork 的 Actions run 历史显示，两次 push 事件均产生了 `event=push` 的 ReleaseWorkflow run（run 32210439746、32210518237），证明**首次推送 workflow 文件即触发**。
+
+---
+
+## 5. 边界情况与注意事项
+
+### 5.1 幂等保护
+
+ReleaseWorkflow 内置 `CheckIfTagExists` 步骤：若 `V<revision>` tag 已存在则跳过创建。因此即使因某种原因重复触发（如同一版本多次合并），也不会报错或覆盖已有 tag。
+
+### 5.2 若确需手动触发（workflow 已合入 main 后）
+
+```bash
+# dry-run 预验证
+gh workflow run ReleaseWorkflow.yml --repo ACANX/MetaOpen --ref main -f dry_run=true
+
+# 正式触发
+gh workflow run ReleaseWorkflow.yml --repo ACANX/MetaOpen --ref main
+```
+
+### 5.3 手动兜底（workflow 异常时）
+
+```bash
+git tag -a V0.8.9 -m "Release V0.8.9"
+git push origin V0.8.9
+gh release create V0.8.9 --generate-notes --repo ACANX/MetaOpen
+```
+
+---
+
+## 6. 结论与建议
+
+1. **发布流程无需等待**：第一次 dev→main 合并即可自动打 tag + 创建 Release
+2. **首次合并前无法手动触发**（workflow_dispatch 平台限制），属正常现象，不影响自动流程
+3. **建议**：正式发布时，dev→main 合并后到 Actions 页面确认 ReleaseWorkflow 已触发；若异常，使用第 5.3 节手动兜底


### PR DESCRIPTION
## 变更内容

### 1. 新增文档（Docs/Release/）

| 文档 | 内容 |
|------|------|
| **PreRelease-Checklist.md** | 正式发版前检查工作清单：版本号、分支与 PR、CI 与构建、依赖与安全、发布流程准备、最终确认（6 大类，可逐项勾选） |
| **PostRelease-Checklist.md** | 发版后收尾/后置工作清单：发布结果确认、Maven Central 发布、安全警报、分支与后续版本、文档记录、遗留事项跟踪（含异常处理速查表） |
| **WorkflowTrigger-Analysis.md** | 首次合并触发 ReleaseWorkflow 问题深入探究：结论、原理分析、实测验证（fork 实验证据）、边界情况与手动兜底 |

### 2. README.md 调整

- **3.3 节**：从详细探究改为精简引用（指向 WorkflowTrigger-Analysis.md），避免主文档冗长
- **新增第 6 章**「发布检查清单与配套文档」：索引三个配套文档
- 章节重排（验证记录从第 6 章调整为第 7 章，小节编号同步修正）

## 文档目录结构（Docs/Release/）

```
Docs/Release/
├── README.md                      # 发布方案总览
├── PreRelease-Checklist.md        # 发版前检查清单（新增）
├── PostRelease-Checklist.md       # 发版后收尾清单（新增）
└── WorkflowTrigger-Analysis.md    # 首次合并触发问题探究（新增）
```