### PR TITLE
docs: 新增 GitHub Action 工作流编写规范（DevSpec/GitHubActionWorkflowSpec.md）

### DIFF
--- a/Docs/DevSpec/GitHubActionWorkflowSpec.md
+++ b/Docs/DevSpec/GitHubActionWorkflowSpec.md
@@ -1,0 +1,163 @@
+# GitHub Action 工作流编写规范（GitHubActionWorkflowSpec）
+
+> 适用范围：MetaOpen 仓库 `.github/workflows/` 目录下的所有 GitHub Actions 工作流文件（`.yml` / `.yaml`）。
+> 最后更新：2026-08-19
+
+---
+
+## 1. 文件命名规范
+
+- **工作流文件名使用大驼峰（PascalCase）命名**，不使用连字符（`-`）、下划线（`_`）或空格。
+- 正确示例：
+  - `ReleaseWorkflow.yml`
+  - `UpdateBOMAIODeps.yml`
+  - `MultiMavenJDKBranchCI.yml`
+  - `SonarCloudCodeAnalysis.yml`
+- 错误示例：
+  - `release-workflow.yml` ❌
+  - `update_bom_deps.yml` ❌
+  - `my workflow.yml` ❌
+- 扩展名统一使用 `.yml`（当前仓库存在 `.yaml` 历史文件，新文件一律使用 `.yml`）。
+
+## 2. 工作流顶层 `name` 规范
+
+- 工作流顶层 `name` 使用大驼峰命名，**不含空格**。
+- 正确示例：`name: ReleaseWorkflow`
+- 错误示例：`name: Release Workflow` ❌
+
+## 3. Job / Step 的 `name` 规范
+
+- **Job 的 `name`、Step 的 `name` 均使用大驼峰命名，中间不使用带空格的 name**。
+- 正确示例：
+  ```yaml
+  jobs:
+    release:
+      runs-on: ubuntu-latest
+      steps:
+        - name: CheckoutCode          # ✅ 大驼峰、无空格
+        - name: ExtractVersionFromPom # ✅ 大驼峰、无空格
+        - name: CreateAndPushTag      # ✅ 大驼峰、无空格
+  ```
+- 错误示例：
+  ```yaml
+  steps:
+    - name: Checkout repository       # ❌ 含空格
+    - name: Build with Maven          # ❌ 含空格
+    - name: Setup Java                # ❌ 含空格
+  ```
+
+### 命名要点
+
+| 原则 | 说明 |
+|------|------|
+| 大驼峰 | 每个单词首字母大写，其余小写，如 `CreateGitHubRelease` |
+| 无空格 | name 中不出现空格、连字符、下划线 |
+| 语义清晰 | 名称应能概括步骤用途，如 `CheckIfTagExists`、`DryRunVerify` |
+| 动词开头 | 步骤名以动词开头（Check / Create / Setup / Build / Publish 等） |
+
+## 4. Step `id` 规范
+
+- Step 的 `id` 使用**小驼峰（camelCase）**命名，与 `name` 风格区分。
+- 正确示例：
+  ```yaml
+  - name: ExtractVersionFromPom
+    id: version
+  - name: CheckIfTagExists
+    id: tag-check
+  ```
+- `id` 用于后续步骤引用（`steps.<id>.outputs.xxx`），命名应简洁且唯一。
+
+## 5. 参考示例
+
+`.github/workflows/ReleaseWorkflow.yml` 是符合本规范的推荐参考示例：
+
+```yaml
+name: ReleaseWorkflow                      # ✅ 顶层 name 大驼峰无空格
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run 模式：仅验证逻辑，不实际创建 tag 和 GitHub Release'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:                                 # ✅ job id 小驼峰
+    runs-on: ubuntu-latest
+    steps:
+      - name: CheckoutCode                 # ✅ step name 大驼峰无空格
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: ExtractVersionFromPom        # ✅
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=<revision>)[^<]+' pom.xml | head -1 | tr -d ' \r\n')
+          TAG="V${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: CheckIfTagExists             # ✅
+        id: tag-check
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: DryRunVerify                 # ✅
+        if: github.event.inputs.dry_run == 'true'
+        run: echo "DRY RUN 验证模式"
+
+      - name: CreateAndPushTag             # ✅
+        if: steps.tag-check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: CreateGitHubRelease          # ✅
+        if: steps.tag-check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
+```
+
+## 6. 其他规范要点
+
+| 项目 | 规范 |
+|------|------|
+| 触发方式 | `on:` 使用仓库内既有惯例；`workflow_dispatch` 的 `inputs` 命名用小驼峰（如 `dry_run`） |
+| 权限 | 显式声明 `permissions:`，遵循最小权限原则（如 `contents: write`） |
+| secrets | 使用 `${{ secrets.XXX }}`，禁止明文密钥 |
+| shell 脚本 | 多行命令用 `run: \|` 块，保持可读性 |
+| 条件执行 | 使用 `if:` 条件（如 `steps.xxx.outputs.xxx == 'true'`），避免整段脚本内判断 |
+| 中文注释 | 关键步骤可加中文注释，与仓库交流语言（简体中文）一致 |
+
+## 7. 检查清单
+
+- [ ] 文件名大驼峰、`.yml` 扩展名
+- [ ] 顶层 `name` 大驼峰无空格
+- [ ] 所有 job / step 的 `name` 大驼峰无空格
+- [ ] step `id` 小驼峰且唯一
+- [ ] 显式 `permissions`，最小权限
+- [ ] 无明文密钥
+
+## 8. 存量文件处理
+
+仓库现有部分 workflow（如 `CodeQLAdvanced.yml`、`SonarQube.yml`）的 step name 仍使用带空格写法。**存量文件不强制立即整改**，但满足以下条件之一时应同步改造为符合本规范：
+- 对存量 workflow 进行功能性修改时
+- 新增 step / job 时
+- 涉及发布、版本管理的核心 workflow（`ReleaseWorkflow.yml`、`UpdateProjectVersion.yml` 等）

--- a/Docs/DevSpec/GitHubActionWorkflowSpec.md
+++ b/Docs/DevSpec/GitHubActionWorkflowSpec.md
@@ -8,6 +8,10 @@
 ## 1. 文件命名规范
 
 - **工作流文件名使用大驼峰（PascalCase）命名**，不使用连字符（`-`）、下划线（`_`）或空格。
+- **文件名必须与工作流文件顶部的 `name` 属性值保持一致**（同名），便于文件与工作流的双向定位。
+  - 正确示例：文件 `ReleaseWorkflow.yml` ↔ `name: ReleaseWorkflow`
+  - 正确示例：文件 `UpdateBOMAIODeps.yml` ↔ `name: UpdateBOMAIODeps`
+  - 错误示例：文件 `Foo.yml` 内部 `name: Bar` ❌（文件名与 name 不一致）
 - 正确示例：
   - `ReleaseWorkflow.yml`
   - `UpdateBOMAIODeps.yml`
@@ -18,6 +22,7 @@
   - `update_bom_deps.yml` ❌
   - `my workflow.yml` ❌
 - 扩展名统一使用 `.yml`（当前仓库存在 `.yaml` 历史文件，新文件一律使用 `.yml`）。
+- 重命名工作流时，文件名与 `name` 属性需同步修改。
 
 ## 2. 工作流顶层 `name` 规范
 
@@ -149,6 +154,7 @@ jobs:
 ## 7. 检查清单
 
 - [ ] 文件名大驼峰、`.yml` 扩展名
+- [ ] **文件名与顶层 `name` 值一致**（同名）
 - [ ] 顶层 `name` 大驼峰无空格
 - [ ] 所有 job / step 的 `name` 大驼峰无空格
 - [ ] step `id` 小驼峰且唯一

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,6 +1,6 @@
 # Docs 文档中心
 
-> MetaOpen 项目文档索引。各文档按主题组织，开发相关文档位于 `Docs/Dev/`，发布相关文档位于 `Docs/Release/`。
+> MetaOpen 项目文档索引。各文档按主题组织：开发入门 `Docs/Dev/`、开发规范 `Docs/DevSpec/`、发布方案 `Docs/Release/`。
 
 ## 文档目录结构
 
@@ -12,11 +12,13 @@ Docs/
 │       ├── BomDependencyAnalysis.md # BOM 依赖版本分析
 │       ├── IncrementalDeploy.md     # 增量发布（mvn deploy -pl）
 │       └── NewArtifactGuide.md      # 如何生成新的 Artifact（archetype）
+├── DevSpec/                         # 开发规范
+│   └── GitHubActionWorkflowSpec.md  # GitHub Action 工作流编写规范
 └── Release/                         # 发布相关文档
     ├── README.md                    # 发布方案总览
-    ├── PreRelease-Checklist.md      # 发版前检查清单
-    ├── PostRelease-Checklist.md     # 发版后收尾清单
-    └── WorkflowTrigger-Analysis.md  # 首次合并触发 ReleaseWorkflow 问题探究
+    ├── PreReleaseChecklist.md       # 发版前检查清单
+    ├── PostReleaseChecklist.md      # 发版后收尾清单
+    └── WorkflowTriggerAnalysis.md   # 首次合并触发 ReleaseWorkflow 问题探究
 ```
 
 ## 开发入门（Docs/Dev/Introduction/）
@@ -27,14 +29,20 @@ Docs/
 | [IncrementalDeploy.md](./Dev/Introduction/IncrementalDeploy.md) | `mvn deploy -pl` 增量发布用法与注意事项 | 局部模块快速发布 |
 | [BomDependencyAnalysis.md](./Dev/Introduction/BomDependencyAnalysis.md) | `mvn help:effective-pom` 分析 BOM 依赖版本 | 排查依赖版本冲突、验证 BOM 导入结果 |
 
+## 开发规范（Docs/DevSpec/）
+
+| 文档 | 内容 | 适用场景 |
+|------|------|---------|
+| [GitHubActionWorkflowSpec.md](./DevSpec/GitHubActionWorkflowSpec.md) | GitHub Action 工作流编写规范（文件/name/step 命名、参考示例） | 新建或修改 `.github/workflows/` 下的工作流 |
+
 ## 发布流程（Docs/Release/）
 
 | 文档 | 内容 | 适用场景 |
 |------|------|---------|
 | [README.md](./Release/README.md) | 发布方案总览（版本管理、ReleaseWorkflow、发布流程） | 了解发布整体机制 |
-| [PreRelease-Checklist.md](./Release/PreRelease-Checklist.md) | 发版前检查工作清单（6 大类） | 每次正式发版前逐项确认 |
-| [PostRelease-Checklist.md](./Release/PostRelease-Checklist.md) | 发版后收尾/后置工作清单（含异常速查） | 发布完成后执行 |
-| [WorkflowTrigger-Analysis.md](./Release/WorkflowTrigger-Analysis.md) | 首次合并触发 ReleaseWorkflow 问题探究 | 理解 push 触发机制与边界情况 |
+| [PreReleaseChecklist.md](./Release/PreReleaseChecklist.md) | 发版前检查工作清单（6 大类） | 每次正式发版前逐项确认 |
+| [PostReleaseChecklist.md](./Release/PostReleaseChecklist.md) | 发版后收尾/后置工作清单（含异常速查） | 发布完成后执行 |
+| [WorkflowTriggerAnalysis.md](./Release/WorkflowTriggerAnalysis.md) | 首次合并触发 ReleaseWorkflow 问题探究 | 理解 push 触发机制与边界情况 |
 
 ## 其他参考
 


### PR DESCRIPTION
## 变更内容

### 1. 新增 `Docs/DevSpec/GitHubActionWorkflowSpec.md`

GitHub Action 工作流编写规范，覆盖：

| 章节 | 内容 |
|------|------|
| 文件命名 | 大驼峰（PascalCase），不使用连字符/下划线/空格，统一 `.yml` 扩展名 |
| 顶层 name | 大驼峰无空格（如 `name: ReleaseWorkflow`） |
| Job/Step name | **大驼峰无空格**（如 `CheckoutCode`、`ExtractVersionFromPom`），列出正反示例 |
| Step id | 小驼峰（camelCase） |
| 参考示例 | **`.github/workflows/ReleaseWorkflow.yml` 作为推荐参考**（完整示例代码） |
| 其他要点 | permissions 最小权限、secrets 用法、shell 块、if 条件、中文注释 |
| 检查清单 | 新建/修改 workflow 时逐项确认 |
| 存量处理 | 存量文件不强制立即整改，功能修改时同步改造 |

### 2. Docs/README.md

- 增加 `Docs/DevSpec/` 目录索引
- Release 文件名同步为大驼峰（PreReleaseChecklist 等，与 #2510 一致）