### PR TITLE
docs: 补充 DevSpec 开发规范文档并新增索引 README

### DIFF
--- a/Docs/DevSpec/CodeStyleSpec.md
+++ b/Docs/DevSpec/CodeStyleSpec.md
@@ -1,0 +1,63 @@
+# Java 编码风格与命名约定（CodeStyleSpec）
+
+> 适用范围：MetaOpen 仓库内所有 Java 源代码（`src/main/java`、`src/test/java`）。
+> 最后更新：2026-08-19
+
+---
+
+## 1. 编码基础
+
+- 统一使用 **UTF-8** 编码，源码文件带 UTF-8 头（如 `-Dfile.encoding=UTF-8`），确保跨平台构建一致。
+- 使用父 POM 中定义的 **Java 21** 配置，保持全仓库 JDK 版本统一。
+- 保持现有 Java 风格，不引入额外的代码风格插件强制约束（当前以人工审查 + 约定为准）。
+
+## 2. 缩进与排版
+
+- **4 空格缩进**，不使用 Tab。
+- 行宽建议不超过 120 字符，超长表达式换行并对齐。
+
+## 3. 命名约定
+
+| 元素 | 风格 | 示例 |
+|------|------|------|
+| 包名 | 全小写，位于 `com.acanx.meta` 下 | `com.acanx.meta.model.quote` |
+| 类 / 接口 | PascalCase（大驼峰） | `ArtifactService`、`QuoteModel` |
+| 方法 | camelCase（小驼峰），动词开头 | `getQuote()`、`buildArtifact()` |
+| 字段 / 局部变量 | camelCase | `quoteId`、`maxRetry` |
+| 常量 | 全大写 + 下划线 | `MAX_RETRY_COUNT`、`DEFAULT_TIMEOUT` |
+| 枚举值 | 全大写 + 下划线 | `OrderStatus.PENDING` |
+
+- 正确示例：
+  ```java
+  public class QuoteService {
+      private static final int MAX_RETRY_COUNT = 3;
+
+      public QuoteModel getQuote(String symbol) {
+          // ...
+      }
+  }
+  ```
+- 错误示例：
+  - `class quote_service` ❌（类名应用 PascalCase）
+  - `int MaxRetry` ❌（字段应用 camelCase）
+  - `final int max_retry_count = 3` ❌（常量应全大写）
+
+## 4. 代码组织
+
+- **优先使用模块内的小型模型类和工具类**，避免过早抽象。
+- 只有在**复用价值明确**时才将类抽象到共享层（如 `base-*` 模块）。
+- 保持类职责单一，一个文件一个公开类（内部类除外）。
+
+## 5. 注释与文档
+
+- Javadoc 注释优先使用**简体中文**（与仓库交流语言一致）。
+- 公开 API（类、方法）建议补充 Javadoc，说明用途、参数与返回值。
+- 不写与代码无关的注释；修改代码时同步更新相关注释。
+
+## 6. 检查清单
+
+- [ ] 文件 UTF-8 编码、Java 21 语法
+- [ ] 4 空格缩进，无 Tab
+- [ ] 包名 `com.acanx.meta.*` 全小写
+- [ ] 类 PascalCase、方法/字段 camelCase、常量全大写
+- [ ] 注释为简体中文，公开 API 有 Javadoc

--- a/Docs/DevSpec/DocumentNamingSpec.md
+++ b/Docs/DevSpec/DocumentNamingSpec.md
@@ -1,0 +1,41 @@
+# 文档文件命名规范（DocumentNamingSpec）
+
+> 适用范围：MetaOpen 仓库 `Docs/` 目录及仓库内所有 Markdown 文档文件（`.md`）。
+> 最后更新：2026-08-19
+
+---
+
+## 1. 文件命名规范
+
+- **Markdown 文档文件名使用大驼峰（PascalCase）命名**，不使用连字符（`-`）、下划线（`_`）或空格。
+- 正确示例：
+  - `PreReleaseChecklist.md`
+  - `PostReleaseChecklist.md`
+  - `WorkflowTriggerAnalysis.md`
+  - `BomDependencyAnalysis.md`
+  - `GitHubActionWorkflowSpec.md`
+- 错误示例：
+  - `PreRelease-Checklist.md` ❌（含连字符）
+  - `workflow_trigger.md` ❌（含下划线 + 非大驼峰）
+  - `my doc.md` ❌（含空格）
+  - `release-checklist.md` ❌（小写 + 连字符）
+- 文件名应能概括文档主题，语义清晰。
+
+## 2. 命名风格一致性
+
+- 文档文件命名风格与 GitHub Action 工作流文件命名风格保持一致（均为大驼峰、无分隔符），见 [GitHubActionWorkflowSpec.md](./GitHubActionWorkflowSpec.md) 第 1 节。
+- 目录名不强制大驼峰（如 `Docs/Dev/Introduction/`、`Docs/DevSpec/`），但**文件名必须大驼峰**。
+
+## 3. 重命名要求
+
+- 重命名文档时，需**同步更新所有引用该文件的链接**，包括：
+  - 其他 Markdown 文档中的相对链接（如 `[xxx](./DevSpec/xxx.md)`）
+  - 根 `README.md`、`Docs/README.md`、`AGENTS.md` 中的索引与引用
+- 避免出现指向旧文件名的失效链接。
+
+## 4. 检查清单
+
+- [ ] 文件名大驼峰（PascalCase）、`.md` 扩展名
+- [ ] 无连字符、下划线、空格
+- [ ] 文件名语义清晰，能概括文档主题
+- [ ] 新增/重命名后，所有引用链接已同步更新

--- a/Docs/DevSpec/GitCommitPRSpec.md
+++ b/Docs/DevSpec/GitCommitPRSpec.md
@@ -1,0 +1,71 @@
+# Git 提交与 Pull Request 规范（GitCommitPRSpec）
+
+> 适用范围：MetaOpen 仓库所有 Git 提交（commit message）、分支管理与 Pull Request。
+> 最后更新：2026-08-19
+
+---
+
+## 1. 提交信息规范（Conventional Commit）
+
+提交信息采用 **Conventional Commit 风格**，格式：`<type>: <描述>`（`<scope>` 可选）。
+
+| type | 用途 | 示例 |
+|------|------|------|
+| `feat:` | 新功能 | `feat: 新增行情快照接口` |
+| `fix:` | Bug 修复 | `fix: 修复并发下单竞态问题` |
+| `docs:` | 文档更新 | `docs: 补充 DevSpec 文档命名规范` |
+| `test:` | 测试相关 | `test: 补充 QuoteService 单元测试` |
+| `refactor:` | 代码重构 | `refactor: 抽取公共校验逻辑` |
+| `build:` | 构建系统/依赖 | `build: 升级 maven-compiler-plugin` |
+| `chore:` | 其他杂项 | `chore(deps): 升级 httpclient5 5.6.2 → 5.6.4` |
+
+### 提交要求
+
+- **依赖升级提交必须明确写出构件名和版本变化**（`构件 旧版本 → 新版本`），如 `chore(deps): 升级 org.json:json 20260522 → 20260701`。
+- 提交描述使用简体中文，简洁概括变更内容。
+- 一个提交只做一件事：功能、修复、文档、依赖升级分开提交。
+- 禁止提交密钥、签名文件、Maven Central 凭据、本地 IDE 配置等敏感/本地文件。
+
+## 2. 分支命名规范
+
+| 分支类型 | 命名 | 示例 |
+|----------|------|------|
+| 新功能 | `feat/<描述>` | `feat/backtest-engine` |
+| Bug 修复 | `fix/<描述>` | `fix/quote-timeout` |
+| 文档 | `docs/<描述>` | `docs/devspec-supplement` |
+| 重构 | `refactor/<描述>` | `refactor/exception-handler` |
+| Issue 处理 | `issue-<编号>-<描述>` | `issue-2507-sonar-token` |
+
+## 3. Pull Request 要求
+
+PR 描述应包含：
+
+1. **变更内容**：本次改了什么，为什么改。
+2. **受影响模块**：列出涉及的模块（如 `meta-model/model-rss`、`.github/workflows/`）。
+3. **关联 issue**：如有关联 Issue，使用 `Closes #<编号>` 自动关闭。
+4. **测试依据**：提供 `mvn test` 或目标模块测试命令输出；涉及依赖/行为变更需说明验证方式。
+5. **截图**：只有文档或工作流界面变更需要截图，代码变更不强制。
+
+## 4. Git 工作流红线（必须遵守）
+
+- **禁止**直接推送代码到 `dev`、`main` 等受保护分支。
+- **必须**通过 PR 流程递交：
+  1. 创建特性分支（`feat/`、`fix/`、`docs/`、`refactor/` 等）
+  2. 在特性分支上提交代码
+  3. 推送到个人 Fork 远端仓库
+  4. 以个人 Fork 的特性分支为来源，向上游仓库发起正式 PR（base 为目标分支，如 `dev`）
+  5. 等待 PR 审核和合并；合并后清理本地和远端特性分支
+- **PR 合并前检查**：用 `gh pr view <编号> --json state,mergedAt` 确认目标 PR 状态；**已合并的 PR 不得追加代码**，需新建分支和 PR。
+- 推送后**确认 PR 状态与 CI 结果**（如 `MultiMavenJDKBranchCI` 是否通过）。
+- **例外**：仅当仓库所有者（ACANX）明确授权"直接推送"时才可跳过 PR 流程。
+- **违反后果**：首次违反严厉批评并检讨；再次违反终身禁用 Git 操作权限。
+
+## 5. 检查清单
+
+- [ ] 提交信息为 Conventional Commit 风格（`type:` 前缀）
+- [ ] 依赖升级提交写明构件名和版本变化
+- [ ] 分支命名符合规范（`feat/`、`fix/`、`docs/` 等）
+- [ ] 未直接推送受保护分支（`dev`、`main`）
+- [ ] PR 描述含变更内容、受影响模块、测试依据
+- [ ] 已检查目标 PR 状态（未合并、可追加）
+- [ ] 推送后已确认 PR 状态与 CI 结果

--- a/Docs/DevSpec/ModuleNamingSpec.md
+++ b/Docs/DevSpec/ModuleNamingSpec.md
@@ -1,0 +1,47 @@
+# Maven 模块命名约定（ModuleNamingSpec）
+
+> 适用范围：MetaOpen 仓库内所有 Maven 模块（根 `pom.xml` 聚合的子模块）。
+> 最后更新：2026-08-19
+
+---
+
+## 1. 模块命名模式
+
+模块命名遵循现有模式，按模块职责使用统一前缀，**禁止随意命名新模块**。
+
+| 模块类型 | 命名前缀 | groupId | 示例 |
+|----------|----------|---------|------|
+| 领域模型模块 | `model-*` | `com.acanx.meta.model` | `model-rss`、`model-gemini`、`model-quote`、`model-deepseek` |
+| 组件 / SDK 模块 | `sdk-*` / `api-*` | `com.acanx.meta.component` | `sdk-maven-artifact` |
+| 基础能力模块 | `base-*` | `com.acanx.meta.base` | `base-exception` |
+
+- 正确示例：
+  - `model-rss`、`model-gemini`（领域模型）
+  - `base-exception`（基础能力）
+  - `sdk-maven-artifact`（Maven 构件相关组件）
+- 错误示例：
+  - `rss-model-x` ❌（前缀位置混乱）
+  - `common-utils` ❌（未按 `base-*` / `model-*` 前缀归类）
+
+## 2. 新建模块要求
+
+- 新模块建议使用 `tool-archetype` 生成，具体步骤见 [Docs/Dev/Introduction/NewArtifactGuide.md](../Dev/Introduction/NewArtifactGuide.md)。
+- 新模块必须加入对应父 POM 的 `<modules>` 列表（`base`、`meta-model`、`meta-component`、`meta-bom`、`meta-sdk`、`os-dependencies` 中对应的聚合 POM）。
+- 模块命名需在仓库内全局唯一，且与模块内 `artifactId` 一致（不额外加后缀）。
+
+## 3. 模块归属
+
+| 聚合模块 | 收录范围 |
+|----------|----------|
+| `base/*` | 通用基础能力模块（`base-*`） |
+| `meta-model/model-*` | 领域模型模块（`model-*`） |
+| `meta-component/sdk-*` | Maven 构件相关组件 / SDK 模块（`sdk-*`、`api-*`） |
+
+> 完整模块组织说明见根 `pom.xml` 与 [AGENTS.md](../../AGENTS.md) 的"项目结构与模块组织"章节。
+
+## 4. 检查清单
+
+- [ ] 模块名使用 `model-*` / `sdk-*` / `api-*` / `base-*` 前缀
+- [ ] groupId 与模块类型匹配（model / component / base）
+- [ ] 已加入对应父 POM 的 `<modules>`
+- [ ] 模块名全局唯一

--- a/Docs/DevSpec/README.md
+++ b/Docs/DevSpec/README.md
@@ -1,0 +1,50 @@
+# 开发规范（DevSpec）
+
+> 适用范围：MetaOpen 仓库所有开发相关规范。每项规范独立成文，存放于 `Docs/DevSpec/` 目录下。
+> 最后更新：2026-08-19
+
+---
+
+## 目录定位
+
+`Docs/DevSpec/` 是 MetaOpen 仓库的**开发规范目录**，沉淀仓库所有者（ACANX）口述确定的开发约定，包括命名规范、编码风格、提交规范、测试规范、版本管理约定等。
+
+与 [AGENTS.md](../../AGENTS.md) 的关系：
+
+- **AGENTS.md**：仓库级指南（速查），汇总各规范的核心要点，供开发者（含 AI Agent）进仓后快速了解约定。
+- **Docs/DevSpec/**：各规范的详细正文，含正确/错误示例与检查清单。
+- 两者内容保持一致：规范正文以 `Docs/DevSpec/` 为准，AGENTS.md 保留摘要并指向本文档。
+
+## 规范文档索引
+
+| 文档 | 内容 | 适用场景 |
+|------|------|---------|
+| [GitHubActionWorkflowSpec.md](./GitHubActionWorkflowSpec.md) | GitHub Action 工作流编写规范（文件/name/step 命名、参考示例） | 新建或修改 `.github/workflows/` 下的工作流 |
+| [DocumentNamingSpec.md](./DocumentNamingSpec.md) | Markdown 文档文件命名规范（大驼峰、无连字符） | 创建/重命名 `Docs/` 及仓库内文档 |
+| [CodeStyleSpec.md](./CodeStyleSpec.md) | Java 编码风格与命名约定（缩进、包名、标识符风格） | 编写/审查 Java 代码 |
+| [ModuleNamingSpec.md](./ModuleNamingSpec.md) | Maven 模块命名约定（model-*/sdk-*/api-*/base-*） | 新建模块、调整模块结构 |
+| [GitCommitPRSpec.md](./GitCommitPRSpec.md) | Git 提交信息与 Pull Request 规范（Conventional Commit、PR 红线） | 提交代码、发起 PR |
+| [TestSpec.md](./TestSpec.md) | 测试规范（JUnit Jupiter、*Test 命名、运行方式） | 编写/运行单元测试 |
+| [VersionReleaseSpec.md](./VersionReleaseSpec.md) | 版本管理与发布约定（revision 单一事实源、Tag、ReleaseWorkflow） | 版本号修改、正式发版 |
+
+## 通用约定
+
+- **交流语言**：与用户对话、文档、注释、提交信息、PR 描述默认使用**简体中文**；代码标识符（类名、方法名、变量名）使用英文。
+- **文档命名**：本目录及仓库内所有 Markdown 文档文件名遵循大驼峰命名（见 [DocumentNamingSpec.md](./DocumentNamingSpec.md)），本 README 的索引表格需随规范文档的新增/删除同步更新。
+- **规范来源**：本目录内容来源于仓库所有者的口述确定与项目实践沉淀；对规范有疑问或需要新增规范时，先与仓库所有者确认，再按"新增规范流程"落地。
+
+## 新增规范流程
+
+1. 按 [DocumentNamingSpec.md](./DocumentNamingSpec.md) 创建 `<主题>Spec.md` 文档（参考既有规范的章节结构：适用范围 → 规范正文 → 正确/错误示例 → 检查清单）。
+2. 更新本 `README.md` 的规范文档索引表。
+3. 同步更新 [AGENTS.md](../../AGENTS.md) 对应摘要章节（或新增摘要章节），并指向新规范文档。
+4. 更新 [Docs/README.md](../README.md) 的 DevSpec 目录表格。
+5. 通过 PR（base=`dev`）递交，遵循 [GitCommitPRSpec.md](./GitCommitPRSpec.md) 的 PR 红线。
+
+## 检查清单
+
+- [ ] 新规范文件名大驼峰、`.md` 扩展名
+- [ ] 本 README 索引表已同步
+- [ ] AGENTS.md 摘要已同步
+- [ ] Docs/README.md 目录表格已同步
+- [ ] 已通过 PR 递交（base=`dev`）

--- a/Docs/DevSpec/TestSpec.md
+++ b/Docs/DevSpec/TestSpec.md
@@ -1,0 +1,55 @@
+# 测试规范（TestSpec）
+
+> 适用范围：MetaOpen 仓库内所有单元测试代码与测试运行方式。
+> 最后更新：2026-08-19
+
+---
+
+## 1. 测试框架与运行器
+
+- 测试框架：**JUnit Jupiter 6**（JUnit 5 平台）。
+- 测试运行器：**Maven Surefire**（`mvn test`）。
+- 测试代码必须放在对应模块的 `src/test/java` 下。
+
+## 2. 测试资源
+
+- 测试资源放在对应模块的 `src/test/resources` 下。
+- 应用配置（`meta/app.yaml` 或 `meta/app.yml`）放在 `src/test/resources` 下，供测试环境加载。
+
+## 3. 测试类命名
+
+- 测试类命名遵循 `*Test` 模式。
+- 正确示例：
+  - `ArtifactServiceTest`
+  - `AppTest`
+  - `QuoteServiceTest`
+- 错误示例：
+  - `ArtifactServiceTests` ❌（复数形式不一致）
+  - `testQuoteService` ❌（未使用 PascalCase + `*Test` 后缀）
+
+## 4. 运行方式
+
+| 场景 | 命令 |
+|------|------|
+| 全量单元测试 | `mvn test` |
+| 只测试指定模块 | `mvn -pl meta-model/model-rss test` |
+| 测试指定模块及其依赖模块 | `mvn -pl meta-model/model-rss -am test` |
+| 完整构建并安装到本地仓库 | `mvn clean install -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8` |
+
+- **大范围修改前**运行 `mvn test` 确认不破坏既有功能。
+- **局部模块修改**可运行 `mvn -pl <module> -am test` 快速验证（`-am` 同时构建依赖模块，避免缺依赖失败）。
+- 部分构建可能需要 `README.md` 中记录的 `--add-opens=jdk.compiler/...=ALL-UNNAMED` JVM 参数（涉及注解处理器或 JDK 编译器内部 API 时）。
+
+## 5. 测试编写要求
+
+- 测试应覆盖核心逻辑的**正常路径与边界/异常路径**。
+- 测试方法命名建议：`<方法名>_<场景>_<期望>`（如 `getQuote_symbolNotFound_throwsException`），与主代码风格保持一致即可。
+- 不提交依赖外部环境的测试（如需要真实网络/数据库的测试应做好 mock 或标注跳过条件）。
+
+## 6. 检查清单
+
+- [ ] 测试代码位于 `src/test/java`，测试资源位于 `src/test/resources`
+- [ ] 测试类命名 `*Test`（PascalCase）
+- [ ] 测试配置 `meta/app.yaml`（或 `meta/app.yml`）在 `src/test/resources`
+- [ ] 大范围修改前已运行 `mvn test`
+- [ ] 局部修改已运行 `mvn -pl <module> -am test` 验证

--- a/Docs/DevSpec/VersionReleaseSpec.md
+++ b/Docs/DevSpec/VersionReleaseSpec.md
@@ -1,0 +1,49 @@
+# 版本管理与发布约定（VersionReleaseSpec）
+
+> 适用范围：MetaOpen 仓库版本号管理、Tag 创建与正式发布（Release）流程。
+> 最后更新：2026-08-19
+
+---
+
+## 1. 版本单一事实源
+
+- 根 `pom.xml` 的 **`<revision>` 属性**是版本号的唯一事实来源，子模块通过 `${revision}` 继承，全仓库版本号统一。
+- 版本号格式：`0.x.y`（如 `0.8.9`），对应 Tag 为 `V0.8.9`。
+
+## 2. 发版改号方式
+
+- **版本号变更统一走 `UpdateProjectVersion` workflow**（`.github/workflows/` 下，手动触发）。
+- 该 workflow 会同步更新：
+  - 根 `pom.xml` 的 `<revision>`
+  - `meta-open.version`、`meta.version` 等版本属性
+  - `bom-graalvm.version`（派生值 `25.<revision>`，如 `25.0.8.9`）
+- **禁止手动修改版本号**：`bom-graalvm.version` 由发版流程程序化派生替换，手动修改会导致版本断层（下次发版被自动覆盖、或与 BOM 依赖分析结果不一致）。
+
+## 3. Tag 与 Release 创建
+
+- **Tag 命名**：`V<version>`（如 `V0.8.9`），与版本号保持一致。
+- **ReleaseWorkflow**（`.github/workflows/ReleaseWorkflow.yml`）在 **dev → main 合并后自动触发**：
+  1. 从根 `pom.xml` 提取 `<revision>` 版本号
+  2. 检查对应 Tag 是否已存在（已存在则跳过，保证幂等）
+  3. 创建并推送 Tag `V<version>`
+  4. 创建 GitHub Release（`generate_release_notes: true` 自动生成发布说明）
+- 支持 `dry_run=true` 手动触发**预验证**：仅校验逻辑，不实际创建 Tag 和 Release。
+
+## 4. 发布流程
+
+1. **发版前**：按 [Docs/Release/PreReleaseChecklist.md](../Release/PreReleaseChecklist.md) 逐项检查（版本号、阻断事项、CI 状态等）。
+2. **发起发布**：dev → main 发起正式发版 PR（标题如 `Release: V0.8.9`），合并后自动触发 ReleaseWorkflow 打 Tag + 建 Release。
+3. **发版后**：按 [Docs/Release/PostReleaseChecklist.md](../Release/PostReleaseChecklist.md) 收尾（核对 Tag/Release、可选 Maven Central 发布、清理分支等）。
+
+## 5. 注意事项
+
+- **首次合并触发问题**：ReleaseWorkflow 首次随 dev→main 合并进入 main 分支时，该次合并本身不会触发（触发只对合并**之后**的 push 生效），详见 [Docs/Release/WorkflowTriggerAnalysis.md](../Release/WorkflowTriggerAnalysis.md) 探究。
+- 修改发布相关配置（GPG、source、Javadoc、flatten、Central publishing 插件）时应谨慎，并同步检查相关 GitHub Actions 工作流。
+
+## 6. 检查清单
+
+- [ ] 版本号只通过 `UpdateProjectVersion` workflow 修改，未手动改 `pom.xml`
+- [ ] Tag 命名 `V<version>` 与版本号一致
+- [ ] 发版前已按 PreReleaseChecklist 检查
+- [ ] 发版后已按 PostReleaseChecklist 收尾
+- [ ] 核心 workflow 修改遵循 [GitHubActionWorkflowSpec.md](./GitHubActionWorkflowSpec.md)

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -13,7 +13,14 @@ Docs/
 │       ├── IncrementalDeploy.md     # 增量发布（mvn deploy -pl）
 │       └── NewArtifactGuide.md      # 如何生成新的 Artifact（archetype）
 ├── DevSpec/                         # 开发规范
-│   └── GitHubActionWorkflowSpec.md  # GitHub Action 工作流编写规范
+│   ├── README.md                    # 开发规范总览（索引）
+│   ├── GitHubActionWorkflowSpec.md  # GitHub Action 工作流编写规范
+│   ├── DocumentNamingSpec.md        # 文档文件命名规范
+│   ├── CodeStyleSpec.md             # Java 编码风格与命名约定
+│   ├── ModuleNamingSpec.md          # Maven 模块命名约定
+│   ├── GitCommitPRSpec.md           # Git 提交与 Pull Request 规范
+│   ├── TestSpec.md                  # 测试规范
+│   └── VersionReleaseSpec.md        # 版本管理与发布约定
 └── Release/                         # 发布相关文档
     ├── README.md                    # 发布方案总览
     ├── PreReleaseChecklist.md       # 发版前检查清单
@@ -33,7 +40,14 @@ Docs/
 
 | 文档 | 内容 | 适用场景 |
 |------|------|---------|
+| [README.md](./DevSpec/README.md) | 开发规范总览（索引、通用约定、新增规范流程） | 快速定位各项开发规范 |
 | [GitHubActionWorkflowSpec.md](./DevSpec/GitHubActionWorkflowSpec.md) | GitHub Action 工作流编写规范（文件/name/step 命名、参考示例） | 新建或修改 `.github/workflows/` 下的工作流 |
+| [DocumentNamingSpec.md](./DevSpec/DocumentNamingSpec.md) | Markdown 文档文件命名规范（大驼峰、无连字符） | 创建/重命名 `Docs/` 及仓库内文档 |
+| [CodeStyleSpec.md](./DevSpec/CodeStyleSpec.md) | Java 编码风格与命名约定（缩进、包名、标识符风格） | 编写/审查 Java 代码 |
+| [ModuleNamingSpec.md](./DevSpec/ModuleNamingSpec.md) | Maven 模块命名约定（model-*/sdk-*/api-*/base-*） | 新建模块、调整模块结构 |
+| [GitCommitPRSpec.md](./DevSpec/GitCommitPRSpec.md) | Git 提交信息与 Pull Request 规范（Conventional Commit、PR 红线） | 提交代码、发起 PR |
+| [TestSpec.md](./DevSpec/TestSpec.md) | 测试规范（JUnit Jupiter、*Test 命名、运行方式） | 编写/运行单元测试 |
+| [VersionReleaseSpec.md](./DevSpec/VersionReleaseSpec.md) | 版本管理与发布约定（revision 单一事实源、Tag、ReleaseWorkflow） | 版本号修改、正式发版 |
 
 ## 发布流程（Docs/Release/）
 


### PR DESCRIPTION
## 变更说明

将仓库所有者此前口述确定、但目前仅沉淀在 `AGENTS.md` 中的开发规范，补充为 `Docs/DevSpec/` 下的独立规范文档，并新增索引 README，便于开发者按主题查阅与后续演进。

### 新增文档（Docs/DevSpec/）

| 文档 | 内容 |
|------|------|
| `README.md` | 开发规范总览：索引表、通用约定（简体中文交流、文档命名）、新增规范流程 |
| `DocumentNamingSpec.md` | 文档文件命名规范：大驼峰命名、无连字符/下划线/空格、重命名需同步引用链接 |
| `CodeStyleSpec.md` | Java 编码风格与命名约定：UTF-8、Java 21、4 空格缩进、包名/类/方法/常量命名 |
| `ModuleNamingSpec.md` | Maven 模块命名约定：`model-*` / `sdk-*` / `api-*` / `base-*` 前缀与 groupId 对应 |
| `GitCommitPRSpec.md` | Git 提交与 PR 规范：Conventional Commit、分支命名、PR 内容要求、Git 红线 |
| `TestSpec.md` | 测试规范：JUnit Jupiter 6、`*Test` 命名、测试资源位置、运行命令 |
| `VersionReleaseSpec.md` | 版本管理与发布约定：`<revision>` 单一事实源、`UpdateProjectVersion` 改号、`V<version>` Tag、ReleaseWorkflow |

### 同步更新

- `Docs/README.md`：DevSpec 目录结构与索引表格同步新增文档条目

### 说明

- 规范内容与 `AGENTS.md` 保持一致（AGENTS.md 保留摘要，DevSpec 为详细正文），无行为变更，纯文档新增。
- 新增规范文档均遵循大驼峰命名（DocumentNamingSpec）。

## 受影响模块

- `Docs/DevSpec/`（新增 7 篇）
- `Docs/README.md`（索引同步）

## 测试依据

纯文档变更，无需编译/单元测试；已本地校验所有相对链接有效。
