### PR TITLE
fix: 修复 SonarCloudCodeAnalysis 质量门禁轮询 403 导致 CI 持续失败

### DIFF
--- a/.github/workflows/SonarCloudCodeAnalysis.yml
+++ b/.github/workflows/SonarCloudCodeAnalysis.yml
@@ -39,4 +39,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # 在GitHub仓库Secrets中设置的SonarCloud Token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub自动提供的Token，用于上传PR检查结果
         run: |
-          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ACANX_MetaOpen -Dsonar.organization=acanx -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=$SONAR_TOKEN -Dsonar.branch.name=${{ github.ref_name }} -Dsonar.qualitygate.wait=true -Dgpg.skip=true -e -X -U 
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ACANX_MetaOpen -Dsonar.organization=acanx -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=$SONAR_TOKEN -Dsonar.branch.name=${{ github.ref_name }} -Dsonar.qualitygate.wait=false -Dgpg.skip=true -e -X -U 


### PR DESCRIPTION
## 问题

Issue #2507：`SonarCloudCodeAnalysis` workflow 持续失败，报错：

```
[ERROR] Not authorized or project not found. Please check the 'SONAR_TOKEN' ...
```

## 根因（已通过对照实验 100% 定位，2026-08-19）

**与 token / 权限 / 免费版无关**，是 SonarCloud 扫描器（sonar-maven-plugin 5.7 + 新分析入口 engine 13.7）的兼容问题：

- 扫描器通过新入口 `POST /api/analysis/analyses`（201）创建分析，拿到的是"分析实体 ID"（如 `5ccfe7c5-...`）
- `-Dsonar.qualitygate.wait=true` 时，扫描器用该 ID 轮询 `GET /api/qualitygates/project_status?analysisId=<实体ID>` —— 该接口只认**快照 UUID**
- SonarCloud 对查不到的快照 ID 返回 **403** → 扫描器报 "Not authorized or project not found"

对照实验（匿名调用）：
- `project_status?analysisId=<真实快照UUID>` → **200** ✅
- `project_status?analysisId=<扫描器实体ID>` → **403** ❌
- `project_status?projectKey=ACANX_MetaOpen` → **200**，质量门禁 **OK** ✅

分析报告本身**始终上传成功**（dashboard 持续有最新分析记录，如 0.8.9 @ 05:39）。

## 修复

- `-Dsonar.qualitygate.wait=true` → `false`：跳过有问题的门禁轮询，扫描照常上传分析报告并成功退出，CI 恢复绿色。
- 质量门禁不受影响：SonarCloud 页面 / GitHub 集成仍展示门禁状态（当前为 OK）。

关联 #2507（合并后 push 流程验证通过即可关闭；PR 流程问题见 issue 评论）
