### PR TITLE
fix: SonarCloudCodeAnalysis 改用 pull_request_target 支持 fork PR 分析

### DIFF
--- a/.github/workflows/SonarCloudCodeAnalysis.yml
+++ b/.github/workflows/SonarCloudCodeAnalysis.yml
@@ -5,8 +5,8 @@ permissions:
 on:
   push:
     branches: [ 'dev', 'main', 'dependa', 'aa' ] # 在推送到主干分支时触发
-  pull_request:
-    branches: [ 'dev', 'main', 'dependa', 'aa' ] # 在任何针对主干分支的PR创建时触发
+  pull_request_target:
+    branches: [ 'dev', 'main', 'dependa', 'aa' ] # 在任何针对主干分支的PR创建时触发（含 fork PR，需显式检出 merge ref）
     types: [opened, synchronize, reopened]
   workflow_dispatch:     
 
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0 # SonarScanner可能需要完整的提交历史
+          # pull_request_target 下默认检出 base 分支，需显式检出 PR 合并提交；push/workflow_dispatch 走事件默认 ref
+          ref: ${{ github.event.pull_request && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
       - name: SetupJDK
         uses: actions/setup-java@v5
@@ -39,4 +41,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # 在GitHub仓库Secrets中设置的SonarCloud Token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub自动提供的Token，用于上传PR检查结果
         run: |
-          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ACANX_MetaOpen -Dsonar.organization=acanx -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=$SONAR_TOKEN -Dsonar.branch.name=${{ github.ref_name }} -Dsonar.qualitygate.wait=false -Dgpg.skip=true -e -X -U 
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ACANX_MetaOpen -Dsonar.organization=acanx -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=$SONAR_TOKEN -Dsonar.qualitygate.wait=false -Dgpg.skip=true -e -X -U # 不传 sonar.branch.name，由扫描器自动识别 push 分支 / PR 上下文 


### PR DESCRIPTION
## 目标

修复 fork PR 流程的 SonarCloud 401：fork 发起的 `pull_request` 事件拿不到 secrets（GitHub 安全机制），改用 `pull_request_target` 让 PR 分析获得 `SONAR_TOKEN`。

## 变更内容

`.github/workflows/SonarCloudCodeAnalysis.yml`：

1. **`pull_request` → `pull_request_target`**：fork PR 与仓库内 PR 统一获得 secrets；工作流文件取 base 分支版本（更安全）
2. **checkout 显式检出 PR 合并提交**：`ref: refs/pull/<编号>/merge`（`pull_request_target` 默认检出 base 分支代码，不指定会扫不到 PR 内容；push/workflow_dispatch 事件走默认 ref，不受影响）
3. **移除 `-Dsonar.branch.name`**：该参数强制"分支模式"并跳过扫描器自动识别（此前 PR 分析被错误当作名为 `<编号>/merge` 的分支分析）；移除后扫描器自动识别 push 分支（dev/main）与 PR 上下文

## 安全说明

`pull_request_target` 使工作流在带 secrets 的环境运行 PR 代码（Maven 构建 + 扫描）。本仓库 PR 仅来自受信任的 `abcnx` 账户，风险可控；如未来开放外部贡献者 PR，需重新评估。

## 合并顺序（重要）

本 PR 基于 #2514（`fix/sonarcloud-qualitygate-403`）的分支创建：
- **请先合并 #2514**（wait=false），本 PR 的 diff 会自动收敛为本次增量
- 若先合并本 PR，#2514 将产生冲突（同一文件同一行），需要 rebase 处理

## 验证方式

合并后：fork 发起的 PR 上 `BuildAndScan` 检查应恢复绿色；push dev/main 的分析不受影响。
