### PR TITLE
fix: ManualBranchCompileVerify 脚本注入修复（SonarCloud S7630 ×4）

### DIFF
--- a/.github/workflows/ManualBranchCompileVerify.yml
+++ b/.github/workflows/ManualBranchCompileVerify.yml
@@ -32,12 +32,17 @@ jobs:
       - name: ResolveBranch
         id: resolve
         shell: bash
+        env:
+          # 用户可控输入经 env 传递，避免直接内插进 shell 脚本（防脚本注入，SonarCloud githubactions:S7630）
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_JAVA_VERSION: ${{ inputs.java_version }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ -n "${{ inputs.branch }}" ]; then
-            echo "branch=${{ inputs.branch }}" >> "$GITHUB_OUTPUT"
-            echo "java=${{ inputs.java_version }}" >> "$GITHUB_OUTPUT"
+          if [ -n "${INPUT_BRANCH}" ]; then
+            echo "branch=${INPUT_BRANCH}" >> "$GITHUB_OUTPUT"
+            echo "java=${INPUT_JAVA_VERSION}" >> "$GITHUB_OUTPUT"
           else
-            echo "branch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+            echo "branch=${HEAD_REF}" >> "$GITHUB_OUTPUT"
             echo "java=25" >> "$GITHUB_OUTPUT"
           fi
 
@@ -50,9 +55,11 @@ jobs:
 
       - name: VerifyPomExists
         shell: bash
+        env:
+          BRANCH: ${{ steps.resolve.outputs.branch }}
         run: |
           echo "PROJECT_DIR=${PROJECT_DIR}"
-          echo "Branch: ${{ steps.resolve.outputs.branch }}"
+          echo "Branch: ${BRANCH}"
           test -f "${PROJECT_DIR}/pom.xml" || { echo "pom.xml not found at ${PROJECT_DIR}/pom.xml"; exit 1; }
 
       - name: SetupTemurinJDK${{ steps.resolve.outputs.java }}
@@ -78,10 +85,13 @@ jobs:
         if: success()
         id: sanitize
         shell: bash
+        env:
+          BRANCH: ${{ steps.resolve.outputs.branch }}
+          JAVA_VERSION: ${{ steps.resolve.outputs.java }}
         run: |
           # Replace invalid characters (/ \ : " < > | * ?) with dash
-          safe=$(echo "${{ steps.resolve.outputs.branch }}" | tr '/\\:"<>|*?' '-' )
-          echo "artifact_name=app-${safe}-jdk${{ steps.resolve.outputs.java }}" >> "$GITHUB_OUTPUT"
+          safe=$(echo "${BRANCH}" | tr '/\\:"<>|*?' '-' )
+          echo "artifact_name=app-${safe}-jdk${JAVA_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: UploadBuildArtifacts
         if: success()


### PR DESCRIPTION
## 问题

SonarCloud 扫描发现 `.github/workflows/ManualBranchCompileVerify.yml` 4 处 **githubactions:S7630 脚本注入（BLOCKER）**：

| 行 | 注入源 |
|----|--------|
| 36/37 | `inputs.branch`（workflow_dispatch 输入，触发者可控制） |
| 38 | `inputs.java_version` |
| 40 | `github.head_ref`（外部参与者可构造特殊值） |

## 修复

用户可控值全部改经 **env 变量**传递，shell 内以 `${VAR}` 引用（官方推荐的防脚本注入姿势）：
- `ResolveBranch`：`inputs.branch` / `inputs.java_version` / `github.head_ref` → env
- `VerifyPomExists`：`steps.resolve.outputs.branch` 引用改 env（同类隐患）
- `SanitizeArtifactName`：`steps.resolve.outputs.branch/java` 引用改 env（同类隐患）

校验：所有 `run:` 块内不再有 `${{ }}` 直接内插。

## 验证

合并到 dev 后触发扫描，SonarCloud 的 4 个 S7630 issue 应自动关闭（或经重扫确认消失）。