### PR TITLE
chore: 第三方 Action 固定完整 SHA + 启用 Dependabot github-actions 生态

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,22 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "23:20"
+      timezone: "Asia/Shanghai"
+    target-branch: "dependa"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "依赖:升级"
+      - "自动化:提交"
+      - "Dependabot"
+      - "From:GitHub-Actions"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:

--- a/.github/workflows/DependabotAutoMergeForMaven.yml
+++ b/.github/workflows/DependabotAutoMergeForMaven.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # 1. 获取元数据
       - name: Get dependency metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@a3e5f86ae9f2f49b441498973ddec20035d326b8
         id: metadata
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/PublishToMavenCentralDependencies.yml
+++ b/.github/workflows/PublishToMavenCentralDependencies.yml
@@ -40,7 +40,7 @@ jobs:
           # 通常会在 pom.xml 或 settings.xml 中配置 gpg 相关信息
 
       - name: ImportGPGKey
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@1c6a9e9d3594f2d743f1b1dd7669ab0dfdffa922
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/ReleaseFullArtifactsByBatch.yaml
+++ b/.github/workflows/ReleaseFullArtifactsByBatch.yaml
@@ -22,7 +22,7 @@ jobs:
           # 通常会在 pom.xml 或 settings.xml 中配置 gpg 相关信息
 
       - name: ImportGPGKey
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@1c6a9e9d3594f2d743f1b1dd7669ab0dfdffa922
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/ReleaseWorkflow.yml
+++ b/.github/workflows/ReleaseWorkflow.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: CreateGitHubRelease
         if: steps.tag-check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/RenameDependabotBumpPRTitle.yml
+++ b/.github/workflows/RenameDependabotBumpPRTitle.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # 1. 获取元数据
       - name: Get dependency metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@a3e5f86ae9f2f49b441498973ddec20035d326b8
         id: metadata
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/UpdateBOMAIODeps.yml
+++ b/.github/workflows/UpdateBOMAIODeps.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: ImportGPGKey
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@1c6a9e9d3594f2d743f1b1dd7669ab0dfdffa922
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: CreatePullRequest
         if: steps.git-check.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(bom-aio): Sync deps from bom-aio-origin BOM"

--- a/.github/workflows/UpdateBomGraalvmVersion.yml
+++ b/.github/workflows/UpdateBomGraalvmVersion.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: CreatePullRequest
         if: steps.git-check.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(deps): update bom-graalvm.version to ${{ steps.check-update.outputs.new_version }}"

--- a/.github/workflows/UpdateProjectVersion.yml
+++ b/.github/workflows/UpdateProjectVersion.yml
@@ -65,7 +65,7 @@ jobs:
           echo "${{ steps.version.outputs.new_version }}" > version
 
       - name: CreatePullRequest
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update project version to ${{ steps.version.outputs.new_version }}"

--- a/Docs/DevSpec/GitHubActionWorkflowSpec.md
+++ b/Docs/DevSpec/GitHubActionWorkflowSpec.md
@@ -150,6 +150,8 @@ jobs:
 | shell 脚本 | 多行命令用 `run: \|` 块，保持可读性 |
 | 条件执行 | 使用 `if:` 条件（如 `steps.xxx.outputs.xxx == 'true'`），避免整段脚本内判断 |
 | 中文注释 | 关键步骤可加中文注释，与仓库交流语言（简体中文）一致 |
+| 第三方 Action 引用 | **固定完整 commit SHA**（如 `crazy-max/ghaction-import-gpg@1c6a9e...`），不使用 tag（`@v3`）；tag 可被移动/删除，SHA 不可变（GitHub 官方安全加固建议，SonarCloud S7637）。版本维护由 Dependabot（github-actions 生态）自动更新 SHA |
+| 官方 Action 引用 | `actions/*`、`github/*` 命名空间可继续用 tag（如 `actions/checkout@v5`），由 GitHub 官方维护 |
 
 ## 7. 检查清单
 


### PR DESCRIPTION
## 背景

SonarCloud S7637（HIGH ×10）：第三方 GitHub Action 用 tag 引用（可变引用，tag 可被移动/删除）。GitHub 官方安全加固建议固定完整 commit SHA。

## 变更

1. **10 处第三方 Action tag → 完整 SHA**（8 个 workflow 文件）：
   - `softprops/action-gh-release@v2` → `@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`
   - `peter-evans/create-pull-request@v6` ×3 → `@c5a7806660adbe173f04e3e038b0ccdcd758773c`
   - `crazy-max/ghaction-import-gpg@v3` ×3 → `@1c6a9e9d3594f2d743f1b1dd7669ab0dfdffa922`
   - `dependabot/fetch-metadata@v1.1.1` ×2 → `@a3e5f86ae9f2f49b441498973ddec20035d326b8`

2. **dependabot.yml 新增 `github-actions` 生态**（每周日检查，target dependa）：
   SHA 固定的版本维护由 Dependabot 自动接管（新版本发布时自动提议更新 SHA），解决"固定 SHA 不便利"问题

3. **GitHubActionWorkflowSpec.md 补充引用规范**：第三方 Action 固定 SHA、官方 `actions/*`/`github/*` 可用 tag

## 说明

- 官方命名空间（`actions/checkout@v5`、`github/codeql-action@v3` 等）未被 SonarCloud 标记，保持 tag 不变
- 纯 workflow 配置变更，无业务代码影响