### PR TITLE
fix: 修复 SonarCloud 已知代码异味并新增 CodeQualitySpec 质量红线规范

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,17 @@ MetaOpen 是一个 Java 21 Maven 多模块项目。根目录 `pom.xml` 聚合 `b
 
 使用 UTF-8 和父 POM 中定义的 Java 21 配置。保持现有 Java 风格：4 空格缩进，包名位于 `com.acanx.meta` 下，类名使用 PascalCase，方法和字段使用 camelCase，常量使用全大写。模块命名遵循现有模式，例如 `model-rss`、`model-gemini` 和 `base-exception`。优先使用模块内的小型模型类和工具类，只有在复用价值明确时才抽象到共享层。
 
+### 代码质量红线（SonarCloud，强制）
+
+SonarCloud 静态扫描是强制环节（push / PR 自动分析），新代码不得新增任何 issue，HIGH 影响问题必须当 PR 内解决。重点规则：
+
+- **S1186 空方法/空构造器**：框架需要无参构造器时保留并在方法体内加嵌套注释说明；无其他构造器且无需保留时直接删除（编译器自动生成等价构造器）；禁止用 `throw new UnsupportedOperationException()` 填满。
+- **S1948 序列化字段**：纯 DTO / POJO / REST 响应对象不实现 `Serializable`（走 Jackson JSON）；异常类不可序列化字段标 `transient` + 注释；禁止在 DTO 字段上标 `transient`（Jackson 会静默丢字段）。
+- **S1192 重复字面量**：同一字符串重复 3 次及以上必须提取常量。
+- **S3776 认知复杂度 ≤ 15**；**S115 常量全大写**；工作流用户可控输入一律经 `env` 传递（S7630/S7631）。
+
+详细决策树、示例与已知问题修复记录见 [CodeQualitySpec.md](./Docs/DevSpec/CodeQualitySpec.md)。
+
 ### 模块命名约定
 
 - 领域模型模块：`model-*`，groupId `com.acanx.meta.model`（如 `model-quote`、`model-deepseek`）

--- a/Docs/DevSpec/CodeQualitySpec.md
+++ b/Docs/DevSpec/CodeQualitySpec.md
@@ -1,0 +1,162 @@
+# Java 代码质量红线规范（CodeQualitySpec）
+
+> 适用范围：MetaOpen 仓库内所有 Java 源代码（`src/main/java`、`src/test/java`）及 GitHub Actions 工作流（`.github/workflows/`）。
+> 状态：**强制要求**。本规范为 SonarCloud 静态扫描（SonarCloudCodeAnalysis 工作流，push / PR 自动分析）的配套红线，后续开发必须遵守，避免再次出现已修复的已知问题。
+> 最后更新：2026-08-19
+
+---
+
+## 1. 总则
+
+- SonarCloud 是项目静态扫描的**强制环节**：push 与 PR 均由 `SonarCloudCodeAnalysis` 工作流自动分析，结果通过 SonarCloud 门禁（Quality Gate）与 `SonarCloud Code Analysis` PR 检查反馈。
+- **红线一：新代码 / 修改代码不得新增任何 SonarCloud issue**；若因业务必要无法避免，必须在 PR 描述中说明原因并给出豁免方式（注释 / `// NOSONAR` / `@SuppressWarnings`）。
+- **红线二：HIGH 影响（CRITICAL 及以上）的问题必须在本 PR 内解决**，不得遗留到后续 PR。
+- **红线三：本规范第 7 节列出的已知问题已全部修复，任何改动不得使其回退复现。**
+
+## 2. S1186 空方法 / 空构造器
+
+> 规则：空方法或空构造器必须说明存在原因，否则视为待办遗留或错误设计。
+
+### 2.1 决策树
+
+| 场景 | 处理方式 |
+|------|----------|
+| 类**没有其他构造器**，且无框架需要 | 直接删除显式空构造器（Java 编译器会自动生成等价默认构造器，字节码层面无差异） |
+| 类**有其他带参构造器** + 框架需要无参构造器 | **保留** + 方法体内嵌套注释（见 2.2） |
+| 类有其他带参构造器 + 框架不需要 | 删除；反序列化需求改用 `@JsonCreator` 等替代方案 |
+| **不确定**（POJO / DTO / 模型类） | 保守处理：保留 + 嵌套注释（防将来新增带参构造器时踩坑） |
+
+### 2.2 必须保留时的写法（官方推荐：嵌套注释）
+
+```java
+public EmailMessage() {
+    // Lombok @Data 不生成构造器，Jackson 反序列化需要默认无参构造器，不可删除
+}
+```
+
+- ✅ 方法体**内部**加注释说明为什么为空（SonarCloud 官方提示 "Add a nested comment explaining why this method is empty"）。
+- ✅ 备选豁免：`@SuppressWarnings("java:S1186")`（方法级）或行尾 `// NOSONAR`。
+- ❌ **禁止**用 `throw new UnsupportedOperationException()` "填满"空构造器——框架实例化时直接抛异常，比空构造器更严重。
+
+### 2.3 需要无参构造器的常见框架（判断依据）
+
+Jackson / Gson 反序列化、JPA / Hibernate 实体、MyBatis resultType 映射、JavaBeans 规范（`java.beans.Introspector`）、Spring CGLIB 代理（`@Configuration` / AOP）、反射实例化（`newInstance()`）。
+
+### 2.4 正确 / 错误示例
+
+```java
+// ✅ 正确：框架需要，嵌套注释说明
+public MVSVMetadata() {
+    // Jackson 等框架反序列化需要默认无参构造器，不可删除
+}
+
+// ✅ 正确：无其他构造器且无需保留，直接删除（编译器自动生成等价构造器）
+
+// ❌ 错误：空构造器无注释，SonarCloud 报 S1186
+public MVSVMetadata() {
+}
+```
+
+## 3. S1948 序列化字段
+
+> 规则：实现 `Serializable` 的类中，非 static 字段必须是可序列化类型或 `transient`。
+
+### 3.1 总原则
+
+- **纯 DTO / POJO / REST 响应对象一律不实现 `Serializable`**。HTTP 场景序列化走 Jackson JSON，不需要 `implements Serializable`；实现反而引入 S1948 风险面。
+- 泛型字段（如 `private T data;`）是 S1948 高发点：泛型 `T` 无 `extends Serializable` 约束，SonarCloud 无法确认可序列化。
+
+### 3.2 各类对象的处理方式
+
+| 对象类型 | 处理方式 |
+|----------|----------|
+| REST 响应 / 请求 DTO、POJO、模型类 | **移除 `implements Serializable`**（连同 `serialVersionUID`、`import java.io.Serializable`），并在类注释说明走 JSON 序列化 |
+| 异常类（继承 `RuntimeException` / `Throwable`，本身即 Serializable） | 不可序列化字段标 `transient` + 注释说明（见 3.3） |
+| 必须实现 Serializable 的业务类 | 泛型字段加 `T extends Serializable` 约束；或字段标 `transient`（仅在确认不参与该对象序列化场景时） |
+
+### 3.3 异常类字段处理（transient 的正确使用场景）
+
+```java
+/**
+ * 国际化参数（高度通用，用于消息模板替换）
+ *
+ * <p>transient：仅在本地用于消息模板替换，跨进程序列化（RMI/分布式）时无需携带，
+ * 避免 java:S1948 告警（Object[] 元素可能不可序列化）。</p>
+ */
+private final transient Object[] args;
+```
+
+### 3.4 ⚠️ transient 陷阱（重点）
+
+- `transient` 只适用于**不参与 Jackson JSON 序列化**的对象（如异常类——异常不直接作为 JSON 响应体）。
+- **禁止**在 DTO / REST 响应对象的字段上标 `transient`：Jackson 默认跳过 transient 字段，会导致该字段**从 API 响应中消失**（静默丢数据，比告警更严重）。
+- 泛型约束 `T extends Serializable` 会**破坏 API 兼容性**（调用方传非 Serializable 类型直接编译失败），不推荐。
+
+### 3.5 正确 / 错误示例
+
+```java
+// ✅ 正确：REST 响应对象不实现 Serializable
+public class RestResult<T> {  // 走 Jackson JSON 序列化
+    private T data;
+}
+
+// ✅ 正确：异常类不可序列化字段标 transient + 注释
+private final transient Map<String, Object> details;
+
+// ❌ 错误：DTO 实现 Serializable 且泛型字段无约束 → S1948
+public class RestResult<T> implements Serializable {
+    private T data;
+}
+
+// ❌ 错误：DTO 字段标 transient → Jackson 序列化时字段静默丢失
+public class RestResult<T> {
+    private transient T data;  // data 从 JSON 响应中消失！
+}
+```
+
+## 4. S1192 重复字符串字面量
+
+> 规则：同一字符串字面量在代码中重复 3 次及以上，必须提取为常量。
+
+```java
+// ✅ 正确：提取常量
+public static final String CHARSET_UTF8_SUFFIX = "; charset=UTF-8";
+public static final String MEDIA_TYPE_APPLICATION_JSON_UTF8 = MEDIA_TYPE_APPLICATION_JSON + CHARSET_UTF8_SUFFIX;
+
+// ❌ 错误：字面量重复 3 次 → S1192
+public static final String MEDIA_TYPE_APPLICATION_JSON_UTF8 = MEDIA_TYPE_APPLICATION_JSON + "; charset=UTF-8";
+```
+
+## 5. 其他 HIGH 规则速查
+
+| 规则 | 含义 | 处理要求 |
+|------|------|----------|
+| S115 | 常量命名不符合 `^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$` | 常量一律全大写 + 下划线 |
+| S3776 | 方法认知复杂度超过阈值（默认 15） | 拆分子方法，控制分支 / 嵌套层级 |
+| S7630 | GitHub Actions 脚本注入（`${{ }}` 内插用户可控输入） | 用户可控输入一律经 `env` 变量传递，禁止在 `run` 块直接内插 |
+| S7631 | GitHub Actions 执行不受信任代码（pull_request_target 场景） | 仅限可信协作者触发；checkout fork 代码须配合 review 与最小权限 token |
+
+## 6. 检查清单（PR 提交前自查）
+
+- [ ] SonarCloud Code Analysis 检查通过，无新增 issue
+- [ ] 空方法 / 空构造器已按 §2 处理（删除或嵌套注释），无裸空构造器
+- [ ] DTO / POJO / REST 响应对象未实现 `Serializable`；异常类 transient 字段已加注释
+- [ ] 重复 3 次及以上的字符串字面量已提取常量
+- [ ] 方法认知复杂度 ≤ 15；常量命名全大写 + 下划线
+- [ ] GitHub Actions 工作流无 `${{ }}` 直接内插用户可控输入
+
+## 7. 已知问题修复记录（2026-08-19）
+
+以下 SonarCloud HIGH 影响问题已按本规范修复（随 PR 合并至 `dev`），**不得回退**：
+
+| Issue Key | 规则 | 位置 | 修复方案 |
+|-----------|------|------|----------|
+| AZ6MITdqyM7RUo22KD2C | S1186 | `base/base-file/.../MVSVMetadata.java:65` | 保留 + 嵌套注释 |
+| AZ6MITjwyM7RUo22KD2x | S1186 | `meta-model/model-mail/.../EmailMessage.java:31` | 保留 + 嵌套注释 |
+| AZ6MITc5yM7RUo22KD18 | S1186 | `base/base-rest/.../domain/Void.java:11` | 保留 + 嵌套注释 |
+| AZ6MITdAyM7RUo22KD19 | S1948 | `base/base-rest/.../RestResult.java:44` | 移除 `implements Serializable` |
+| AZ6MITcgyM7RUo22KD11 | S1948 | `base/base-exception/.../BaseException.java:27` | `args` 标 transient + 注释 |
+| AZ6MITcwyM7RUo22KD17 | S1948 | `base/base-exception/.../BusinessException.java:30` | `details` 标 transient + 注释 |
+| AZ6MITcOyM7RUo22KD1x | S1192 | `base/base-http/.../BaseHttpConst.java:55` | 提取 `CHARSET_UTF8_SUFFIX` 常量 |
+
+> 关联规范：编码风格见 [CodeStyleSpec.md](./CodeStyleSpec.md)、测试规范见 [TestSpec.md](./TestSpec.md)、PR 流程见 [GitCommitPRSpec.md](./GitCommitPRSpec.md)。

--- a/Docs/DevSpec/README.md
+++ b/Docs/DevSpec/README.md
@@ -22,6 +22,7 @@
 | [GitHubActionWorkflowSpec.md](./GitHubActionWorkflowSpec.md) | GitHub Action 工作流编写规范（文件/name/step 命名、参考示例） | 新建或修改 `.github/workflows/` 下的工作流 |
 | [DocumentNamingSpec.md](./DocumentNamingSpec.md) | Markdown 文档文件命名规范（大驼峰、无连字符） | 创建/重命名 `Docs/` 及仓库内文档 |
 | [CodeStyleSpec.md](./CodeStyleSpec.md) | Java 编码风格与命名约定（缩进、包名、标识符风格） | 编写/审查 Java 代码 |
+| [CodeQualitySpec.md](./CodeQualitySpec.md) | Java 代码质量红线（SonarCloud 强制规范：S1186 空构造器、S1948 序列化、S1192 重复字面量等） | 编写/审查 Java 代码、GitHub Actions 工作流 |
 | [ModuleNamingSpec.md](./ModuleNamingSpec.md) | Maven 模块命名约定（model-*/sdk-*/api-*/base-*） | 新建模块、调整模块结构 |
 | [GitCommitPRSpec.md](./GitCommitPRSpec.md) | Git 提交信息与 Pull Request 规范（Conventional Commit、PR 红线） | 提交代码、发起 PR |
 | [TestSpec.md](./TestSpec.md) | 测试规范（JUnit Jupiter、*Test 命名、运行方式） | 编写/运行单元测试 |

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -52,6 +52,7 @@ Docs/
 | [GitHubActionWorkflowSpec.md](./DevSpec/GitHubActionWorkflowSpec.md) | GitHub Action 工作流编写规范（文件/name/step 命名、参考示例） | 新建或修改 `.github/workflows/` 下的工作流 |
 | [DocumentNamingSpec.md](./DevSpec/DocumentNamingSpec.md) | Markdown 文档文件命名规范（大驼峰、无连字符） | 创建/重命名 `Docs/` 及仓库内文档 |
 | [CodeStyleSpec.md](./DevSpec/CodeStyleSpec.md) | Java 编码风格与命名约定（缩进、包名、标识符风格） | 编写/审查 Java 代码 |
+| [CodeQualitySpec.md](./DevSpec/CodeQualitySpec.md) | Java 代码质量红线（SonarCloud 强制规范：S1186 空构造器、S1948 序列化、S1192 重复字面量等） | 编写/审查 Java 代码、GitHub Actions 工作流 |
 | [ModuleNamingSpec.md](./DevSpec/ModuleNamingSpec.md) | Maven 模块命名约定（model-*/sdk-*/api-*/base-*） | 新建模块、调整模块结构 |
 | [GitCommitPRSpec.md](./DevSpec/GitCommitPRSpec.md) | Git 提交信息与 Pull Request 规范（Conventional Commit、PR 红线） | 提交代码、发起 PR |
 | [TestSpec.md](./DevSpec/TestSpec.md) | 测试规范（JUnit Jupiter、*Test 命名、运行方式） | 编写/运行单元测试 |

--- a/base/base-exception/src/main/java/com/acanx/meta/base/exception/BaseException.java
+++ b/base/base-exception/src/main/java/com/acanx/meta/base/exception/BaseException.java
@@ -23,8 +23,11 @@ public class BaseException extends RuntimeException {
     /**
      * 国际化参数（高度通用，用于消息模板替换）
      * 例：消息模板"用户名【{0}】已存在" → args=["张三"]
+     *
+     * <p>transient：仅在本地用于消息模板替换，跨进程序列化（RMI/分布式）时无需携带，
+     * 避免 java:S1948 告警（Object[] 元素可能不可序列化）。</p>
      */
-    private final Object[] args;
+    private final transient Object[] args;
 
     public BaseException() {
         super();

--- a/base/base-exception/src/main/java/com/acanx/meta/base/exception/BusinessException.java
+++ b/base/base-exception/src/main/java/com/acanx/meta/base/exception/BusinessException.java
@@ -26,8 +26,11 @@ public class BusinessException extends BaseException {
     /**
      * 错误详情（可选，用于结构化错误信息）
      * 例：字段级校验错误、批量操作失败详情
+     *
+     * <p>transient：仅在本地用于错误详情展示，跨进程序列化时无需携带，
+     * 避免 java:S1948 告警（Map value 可能不可序列化）。</p>
      */
-    private final Map<String, Object> details;
+    private final transient Map<String, Object> details;
 
     public BusinessException() {
         super();

--- a/base/base-file/src/main/java/com/acanx/meta/base/file/mvsv/MVSVMetadata.java
+++ b/base/base-file/src/main/java/com/acanx/meta/base/file/mvsv/MVSVMetadata.java
@@ -60,9 +60,10 @@ public class MVSVMetadata {
     private Map<String, String> extra = new HashMap<>();
 
     /**
-     * 默认构造函数
+     * 默认无参构造器
      */
     public MVSVMetadata() {
+        // Jackson 等框架反序列化需要默认无参构造器，不可删除（SonarCloud java:S1186 豁免）
     }
 
     /**

--- a/base/base-http/src/main/java/com/acanx/meta/base/http/c/BaseHttpConst.java
+++ b/base/base-http/src/main/java/com/acanx/meta/base/http/c/BaseHttpConst.java
@@ -52,9 +52,13 @@ public final class BaseHttpConst {
     public static final String MEDIA_TYPE_TEXT_HTML = "text/html";
     public static final String MEDIA_TYPE_TEXT_CSS = "text/css";
     public static final String MEDIA_TYPE_TEXT_EVENT_STREAM = "text/event-stream";
-    public static final String MEDIA_TYPE_APPLICATION_JSON_UTF8 = MEDIA_TYPE_APPLICATION_JSON + "; charset=UTF-8";
-    public static final String MEDIA_TYPE_TEXT_PLAIN_UTF8 = MEDIA_TYPE_TEXT_PLAIN + "; charset=UTF-8";
-    public static final String MEDIA_TYPE_TEXT_HTML_UTF8 = MEDIA_TYPE_TEXT_HTML + "; charset=UTF-8";
+
+    /** UTF-8 字符集媒体类型后缀 */
+    public static final String CHARSET_UTF8_SUFFIX = "; charset=UTF-8";
+
+    public static final String MEDIA_TYPE_APPLICATION_JSON_UTF8 = MEDIA_TYPE_APPLICATION_JSON + CHARSET_UTF8_SUFFIX;
+    public static final String MEDIA_TYPE_TEXT_PLAIN_UTF8 = MEDIA_TYPE_TEXT_PLAIN + CHARSET_UTF8_SUFFIX;
+    public static final String MEDIA_TYPE_TEXT_HTML_UTF8 = MEDIA_TYPE_TEXT_HTML + CHARSET_UTF8_SUFFIX;
 
     public static final String SCHEME_HTTP = "http";
     public static final String SCHEME_HTTPS = "https";

--- a/base/base-rest/src/main/java/com/acanx/meta/base/rest/RestResult.java
+++ b/base/base-rest/src/main/java/com/acanx/meta/base/rest/RestResult.java
@@ -3,21 +3,21 @@ package com.acanx.meta.base.rest;
 import com.acanx.meta.base.error.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import java.io.Serializable;
-
 /**
  * RestResult
  *
  * 统一REST API响应对象
+ *
+ * <p>仅通过 Jackson 进行 JSON 序列化（HTTP 响应），不参与 Java 原生序列化，
+ * 故不实现 {@link java.io.Serializable}，避免泛型字段 {@code data} 触发
+ * SonarCloud java:S1948 告警。</p>
  *
  * @param <T> 数据类型
  * @author ACANX
  * @since 0.1.5
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class RestResult<T> implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class RestResult<T> {
 
     /**
      * 成功状态码

--- a/base/base-rest/src/main/java/com/acanx/meta/base/rest/domain/Void.java
+++ b/base/base-rest/src/main/java/com/acanx/meta/base/rest/domain/Void.java
@@ -9,5 +9,6 @@ package com.acanx.meta.base.rest.domain;
 public class Void {
 
     public Void() {
+        // 空响应类型（如 RestResult<Void>），Jackson 反序列化需要默认无参构造器，不可删除（SonarCloud java:S1186 豁免）
     }
 }

--- a/meta-model/model-mail/src/main/java/com/acanx/meta/model/email/EmailMessage.java
+++ b/meta-model/model-mail/src/main/java/com/acanx/meta/model/email/EmailMessage.java
@@ -29,5 +29,6 @@ public class EmailMessage {
     private List<String> attachments;
 
     public EmailMessage() {
+        // Lombok @Data 不生成构造器，Jackson 反序列化需要默认无参构造器，不可删除（SonarCloud java:S1186 豁免）
     }
 }


### PR DESCRIPTION
## 背景

SonarCloud 项目存在 14 个 HIGH 影响 OPEN issue，本次修复其中**同类快速修复类**（S1186/S1948/S1192 共 7 处），并将修复方案固化为 DevSpec 强制规范，防止再次出现。

## 代码修复（7 处）

### S1186 空方法/空构造器 ×3（保留 + 官方推荐的方法体内嵌套注释）
| 文件 | 说明 |
|------|------|
| `MVSVMetadata.java:65` | Jackson 反序列化需要默认无参构造器 |
| `EmailMessage.java:31` | Lombok @Data 不生成构造器，Jackson 需要 |
| `domain/Void.java:11` | 空响应类型（RestResult\<Void\>），Jackson 需要 |

### S1948 序列化字段 ×3
| 文件 | 方案 |
|------|------|
| `RestResult.java:44` | **移除 implements Serializable**（纯 REST JSON 响应，全仓库无原生序列化场景，已排查） |
| `BaseException.java:27` | `args` 标 `transient` + 注释（异常类本身 Serializable，跨进程无需携带） |
| `BusinessException.java:30` | `details` 标 `transient` + 注释 |

### S1192 重复字面量 ×1
- `BaseHttpConst.java`："; charset=UTF-8" 重复 3 次 → 提取 `CHARSET_UTF8_SUFFIX` 常量

## 规范落地

新增 `Docs/DevSpec/CodeQualitySpec.md`（Java 代码质量红线，**强制要求**）：
- S1186 空构造器决策树（何时删/何时保留+嵌套注释，禁止 throw UnsupportedOperationException 填满）
- S1948 序列化规范（DTO 不实现 Serializable；异常类 transient；⚠️ transient 的 Jackson 静默丢字段陷阱）
- S1192 常量提取、S3776 认知复杂度、S7630/S7631 工作流注入速查
- 红线：新代码不得新增 SonarCloud issue；HIGH 问题必须当 PR 内解决
- 已修复 7 个 issue 的清单记录，防止回退

同步更新：`DevSpec/README.md`、`Docs/README.md` 索引 + `AGENTS.md` 摘要速查。

## 验证

- [x] 改动均无外部 Serializable 依赖（全仓库排查）
- [x] transient 不影响构造器赋值与 getter
- [x] 常量无命名冲突
- CI 编译验证由 BuildAndScan 执行（本地无 Maven 环境）

## 关联

- SonarCloud issues：AZ6MITdqyM7RUo22KD2C / AZ6MITjwyM7RUo22KD2x / AZ6MITc5yM7RUo22KD18 / AZ6MITdAyM7RUo22KD19 / AZ6MITcgyM7RUo22KD11 / AZ6MITcwyM7RUo22KD17 / AZ6MITcOyM7RUo22KD1x
- 剩余未处理 HIGH issue（不在本次范围）：S3776 认知复杂度×2（MVSVSerializer 需重构设计）、S115 常量命名×4（RssConst/ArtifactServiceTest）、S7631 fork 不可信代码×1（主线 pull_request_target 设计权衡）