### PR TITLE
fix: 修复 #2541 已勾选项（S1128×3 + S115×4）

### DIFF
--- a/base/base-exception/src/main/java/com/acanx/meta/base/exception/BusinessException.java
+++ b/base/base-exception/src/main/java/com/acanx/meta/base/exception/BusinessException.java
@@ -1,6 +1,5 @@
 package com.acanx.meta.base.exception;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/base/base-exception/src/test/java/com/acanx/meta/base/exception/BusinessExceptionTest.java
+++ b/base/base-exception/src/test/java/com/acanx/meta/base/exception/BusinessExceptionTest.java
@@ -2,9 +2,6 @@ package com.acanx.meta.base.exception;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
+++ b/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
@@ -41,6 +41,12 @@ public class RssConst {
      */
     public static final String URL_XMLNS_CONTENT = "http://purl.org/rss/1.0/modules/content/";
 
+    /**
+     * Atom命名空间URI副本
+     * 与XMLNS_ATOM相同，可能是为了代码中的不同使用场景而定义
+     */
+    public static final String URL_XMLNS_ATOM_ = "https://www.rss.com/api/v1/rss/feed/";
+
 
     /**
      * 简体中文语言代码常量

--- a/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
+++ b/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
@@ -42,10 +42,16 @@ public class RssConst {
     public static final String URL_XMLNS_CONTENT = "http://purl.org/rss/1.0/modules/content/";
 
     /**
-     * Atom命名空间URI副本
-     * 与XMLNS_ATOM相同，可能是为了代码中的不同使用场景而定义
+     * RSS feed 基础 URL
+     *
+     * ⚠️ 命名历史（2026-08-19 SonarCloud java:S115 规范修复）：
+     * 原常量名 {@code URL_XMLNS_ATOM_}（尾部下划线不符合命名规范
+     * {@code ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$}），经确认后调整为本名。
+     * 原注释称"与XMLNS_ATOM相同"，但实际值为 RSS feed 地址
+     * （与 {@link #RSS_URL_V1_1} 值相同），故按真实语义命名。
+     * 如需追溯旧引用，请在代码库中搜索 {@code URL_XMLNS_ATOM_}。
      */
-    public static final String URL_XMLNS_ATOM_ = "https://www.rss.com/api/v1/rss/feed/";
+    public static final String URL_RSS_FEED = "https://www.rss.com/api/v1/rss/feed/";
 
 
     /**

--- a/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
+++ b/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
@@ -41,13 +41,6 @@ public class RssConst {
      */
     public static final String URL_XMLNS_CONTENT = "http://purl.org/rss/1.0/modules/content/";
 
-    /**
-     * Atom命名空间URI副本
-     * 与XMLNS_ATOM相同，可能是为了代码中的不同使用场景而定义
-     */
-    public static final String URL_XMLNS_ATOM = "https://www.rss.com/api/v1/rss/feed/";
-
-
 
     /**
      * 简体中文语言代码常量

--- a/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
+++ b/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
@@ -45,7 +45,7 @@ public class RssConst {
      * Atom命名空间URI副本
      * 与XMLNS_ATOM相同，可能是为了代码中的不同使用场景而定义
      */
-    public static final String URL_XMLNS_ATOM_ = "https://www.rss.com/api/v1/rss/feed/";
+    public static final String URL_XMLNS_ATOM = "https://www.rss.com/api/v1/rss/feed/";
 
 
 

--- a/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/maven/artifact/ArtifactServiceTest.java
+++ b/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/maven/artifact/ArtifactServiceTest.java
@@ -9,17 +9,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ArtifactServiceTest {
 
-    public static final String groupId = "com.acanx.util";
+    public static final String GROUP_ID = "com.acanx.util";
 
-    public static final String artifactId = "autil-core";
+    public static final String ARTIFACT_ID = "autil-core";
 
-    public static final String version = "0.2.0.2";
+    public static final String VERSION = "0.2.0.2";
 
     public static final ArtifactService service =  new ArtifactService();
 
     @Test
     void getMavenArtifactFromMetaDataFile() {
-       MavenArtifact mavenArtifact = service.getMavenArtifactFromMetaDataFile(groupId, artifactId);
+       MavenArtifact mavenArtifact = service.getMavenArtifactFromMetaDataFile(GROUP_ID, ARTIFACT_ID);
        System.out.println(mavenArtifact.toString());
        System.out.println(JSONUtil.toJSONStringPrettyFormat(mavenArtifact));
 
@@ -28,7 +28,7 @@ class ArtifactServiceTest {
 
     @Test
     void getArtifactFromLatestVersionPomFile() {
-        MavenArtifact mavenArtifact = service.getArtifactFromLatestVersionPomFile(groupId, artifactId, version);
+        MavenArtifact mavenArtifact = service.getArtifactFromLatestVersionPomFile(GROUP_ID, ARTIFACT_ID, VERSION);
         System.out.println(JSONUtil.toJSONStringPrettyFormat(mavenArtifact));
         assertNotNull(mavenArtifact);
     }


### PR DESCRIPTION
## 背景

按父 issue #2541（SJ5 命名/import/杂项）已勾选（✅）项目修复，子 issue #2548 跟踪本批次。未勾选 8 项留待后续分批。

## 变更内容（7 项）

| 编号 | 规则 | 文件 | 修改 |
|------|------|------|------|
| SJ5-1 | S1128 | BusinessException.java:3 | 删除未使用 import java.util.HashMap |
| SJ5-2 | S1128 | BusinessExceptionTest.java:5 | 删除未使用 import java.util.HashMap |
| SJ5-3 | S1128 | BusinessExceptionTest.java:6 | 删除未使用 import java.util.Map |
| SJ5-7 | S115 | RssConst.java:48 | URL_XMLNS_ATOM_ → URL_XMLNS_ATOM（无外部引用） |
| SJ5-13 | S115 | ArtifactServiceTest.java:12 | groupId → GROUP_ID |
| SJ5-14 | S115 | ArtifactServiceTest.java:14 | artifactId → ARTIFACT_ID |
| SJ5-15 | S115 | ArtifactServiceTest.java:16 | version → VERSION |

ArtifactServiceTest 中 2 处调用同步更新（getMavenArtifactFromMetaDataFile / getArtifactFromLatestVersionPomFile）。

## 验证

- 4 个文件、6+/10-，均为 import 删除与常量改名
- 无残留旧引用（已 grep 确认）

Closes #2548