### PR TITLE
chore: SonarCloudCodeAnalysis job 改名 BuildAndScan → BuildScanAnalyze

### DIFF
--- a/.github/workflows/SonarCloudCodeAnalysis.yml
+++ b/.github/workflows/SonarCloudCodeAnalysis.yml
@@ -12,7 +12,7 @@ on:
 
   
 jobs:
-  BuildAndScan:
+  BuildScanAnalyze:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/base/base-exception/src/main/java/com/acanx/meta/base/exception/BusinessException.java
+++ b/base/base-exception/src/main/java/com/acanx/meta/base/exception/BusinessException.java
@@ -1,6 +1,5 @@
 package com.acanx.meta.base.exception;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/base/base-exception/src/test/java/com/acanx/meta/base/exception/BusinessExceptionTest.java
+++ b/base/base-exception/src/test/java/com/acanx/meta/base/exception/BusinessExceptionTest.java
@@ -2,9 +2,6 @@ package com.acanx.meta.base.exception;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/base/base-file/src/main/java/com/acanx/meta/base/file/mvsv/MVSVSerializer.java
+++ b/base/base-file/src/main/java/com/acanx/meta/base/file/mvsv/MVSVSerializer.java
@@ -135,44 +135,44 @@ public class MVSVSerializer {
     private void writeMetadataToBuilder(StringBuilder builder, MVSVMetadata metadata) {
         // 中文元数据
         if (metadata.getTitle() != null && !metadata.getTitle().isEmpty()) {
-            builder.append(String.format("# 标题 : \"%s\"\n", metadata.getTitle()));
+            builder.append(String.format("# 标题 : \"%s\"%n", metadata.getTitle()));
         }
         if (metadata.getDataProvider() != null && !metadata.getDataProvider().isEmpty()) {
-            builder.append(String.format("# 数据供应商 : %s\n", metadata.getDataProvider()));
+            builder.append(String.format("# 数据供应商 : %s%n", metadata.getDataProvider()));
         }
         if (metadata.getField() != null && !metadata.getField().isEmpty()) {
-            builder.append(String.format("# 字段 : %s\n", metadata.getField()));
+            builder.append(String.format("# 字段 : %s%n", metadata.getField()));
         }
         if (metadata.getFieldName() != null && !metadata.getFieldName().isEmpty()) {
-            builder.append(String.format("# 字段名称 : %s\n", metadata.getFieldName()));
+            builder.append(String.format("# 字段名称 : %s%n", metadata.getFieldName()));
         }
         if (metadata.getFieldType() != null && !metadata.getFieldType().isEmpty()) {
-            builder.append(String.format("# 字段类型 : %s\n", metadata.getFieldType()));
+            builder.append(String.format("# 字段类型 : %s%n", metadata.getFieldType()));
         }
-        builder.append(String.format("# 计数 : %d\n", metadata.getCount()));
+        builder.append(String.format("# 计数 : %d%n", metadata.getCount()));
         if (metadata.getRemark() != null && !metadata.getRemark().isEmpty()) {
-            builder.append(String.format("# 备注 : \"%s\"\n", metadata.getRemark()));
+            builder.append(String.format("# 备注 : \"%s\"%n", metadata.getRemark()));
         }
 
         // 英文元数据
         if (metadata.getTitleEn() != null && !metadata.getTitleEn().isEmpty()) {
-            builder.append(String.format("# Title : \"%s\"\n", metadata.getTitleEn()));
+            builder.append(String.format("# Title : \"%s\"%n", metadata.getTitleEn()));
         }
         if (metadata.getDataProviderEn() != null && !metadata.getDataProviderEn().isEmpty()) {
-            builder.append(String.format("# DataProvider : %s\n", metadata.getDataProviderEn()));
+            builder.append(String.format("# DataProvider : %s%n", metadata.getDataProviderEn()));
         }
         if (metadata.getFieldEn() != null && !metadata.getFieldEn().isEmpty()) {
-            builder.append(String.format("# Field : %s\n", metadata.getFieldEn()));
+            builder.append(String.format("# Field : %s%n", metadata.getFieldEn()));
         }
         if (metadata.getFieldNameEn() != null && !metadata.getFieldNameEn().isEmpty()) {
-            builder.append(String.format("# FieldName : %s\n", metadata.getFieldNameEn()));
+            builder.append(String.format("# FieldName : %s%n", metadata.getFieldNameEn()));
         }
         if (metadata.getFieldTypeEn() != null && !metadata.getFieldTypeEn().isEmpty()) {
-            builder.append(String.format("# FieldType : %s\n", metadata.getFieldTypeEn()));
+            builder.append(String.format("# FieldType : %s%n", metadata.getFieldTypeEn()));
         }
-        builder.append(String.format("# Count : %d\n", metadata.getCount()));
+        builder.append(String.format("# Count : %d%n", metadata.getCount()));
         if (metadata.getRemarkEn() != null && !metadata.getRemarkEn().isEmpty()) {
-            builder.append(String.format("# Remark : \"%s\"\n", metadata.getRemarkEn()));
+            builder.append(String.format("# Remark : \"%s\"%n", metadata.getRemarkEn()));
         }
     }
 

--- a/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
+++ b/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
@@ -41,6 +41,12 @@ public class RssConst {
      */
     public static final String URL_XMLNS_CONTENT = "http://purl.org/rss/1.0/modules/content/";
 
+    /**
+     * Atom命名空间URI副本
+     * 与XMLNS_ATOM相同，可能是为了代码中的不同使用场景而定义
+     */
+    public static final String URL_XMLNS_ATOM_ = "https://www.rss.com/api/v1/rss/feed/";
+
 
     /**
      * 简体中文语言代码常量

--- a/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
+++ b/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
@@ -42,10 +42,16 @@ public class RssConst {
     public static final String URL_XMLNS_CONTENT = "http://purl.org/rss/1.0/modules/content/";
 
     /**
-     * Atom命名空间URI副本
-     * 与XMLNS_ATOM相同，可能是为了代码中的不同使用场景而定义
+     * RSS feed 基础 URL
+     *
+     * ⚠️ 命名历史（2026-08-19 SonarCloud java:S115 规范修复）：
+     * 原常量名 {@code URL_XMLNS_ATOM_}（尾部下划线不符合命名规范
+     * {@code ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$}），经确认后调整为本名。
+     * 原注释称"与XMLNS_ATOM相同"，但实际值为 RSS feed 地址
+     * （与 {@link #RSS_URL_V1_1} 值相同），故按真实语义命名。
+     * 如需追溯旧引用，请在代码库中搜索 {@code URL_XMLNS_ATOM_}。
      */
-    public static final String URL_XMLNS_ATOM_ = "https://www.rss.com/api/v1/rss/feed/";
+    public static final String URL_RSS_FEED = "https://www.rss.com/api/v1/rss/feed/";
 
 
     /**

--- a/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
+++ b/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
@@ -41,13 +41,6 @@ public class RssConst {
      */
     public static final String URL_XMLNS_CONTENT = "http://purl.org/rss/1.0/modules/content/";
 
-    /**
-     * Atom命名空间URI副本
-     * 与XMLNS_ATOM相同，可能是为了代码中的不同使用场景而定义
-     */
-    public static final String URL_XMLNS_ATOM = "https://www.rss.com/api/v1/rss/feed/";
-
-
 
     /**
      * 简体中文语言代码常量

--- a/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
+++ b/meta-model/model-rss/src/main/java/com/acanx/meta/c/RssConst.java
@@ -45,7 +45,7 @@ public class RssConst {
      * Atom命名空间URI副本
      * 与XMLNS_ATOM相同，可能是为了代码中的不同使用场景而定义
      */
-    public static final String URL_XMLNS_ATOM_ = "https://www.rss.com/api/v1/rss/feed/";
+    public static final String URL_XMLNS_ATOM = "https://www.rss.com/api/v1/rss/feed/";
 
 
 

--- a/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/maven/artifact/ArtifactServiceTest.java
+++ b/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/maven/artifact/ArtifactServiceTest.java
@@ -9,17 +9,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ArtifactServiceTest {
 
-    public static final String groupId = "com.acanx.util";
+    public static final String GROUP_ID = "com.acanx.util";
 
-    public static final String artifactId = "autil-core";
+    public static final String ARTIFACT_ID = "autil-core";
 
-    public static final String version = "0.2.0.2";
+    public static final String VERSION = "0.2.0.2";
 
     public static final ArtifactService service =  new ArtifactService();
 
     @Test
     void getMavenArtifactFromMetaDataFile() {
-       MavenArtifact mavenArtifact = service.getMavenArtifactFromMetaDataFile(groupId, artifactId);
+       MavenArtifact mavenArtifact = service.getMavenArtifactFromMetaDataFile(GROUP_ID, ARTIFACT_ID);
        System.out.println(mavenArtifact.toString());
        System.out.println(JSONUtil.toJSONStringPrettyFormat(mavenArtifact));
 
@@ -28,7 +28,7 @@ class ArtifactServiceTest {
 
     @Test
     void getArtifactFromLatestVersionPomFile() {
-        MavenArtifact mavenArtifact = service.getArtifactFromLatestVersionPomFile(groupId, artifactId, version);
+        MavenArtifact mavenArtifact = service.getArtifactFromLatestVersionPomFile(GROUP_ID, ARTIFACT_ID, VERSION);
         System.out.println(JSONUtil.toJSONStringPrettyFormat(mavenArtifact));
         assertNotNull(mavenArtifact);
     }


### PR DESCRIPTION
## 变更

`SonarCloudCodeAnalysis.yml` 的 job 名 `BuildAndScan` → `BuildScanAnalyze`：

- 更准确反映职责：构建(Build) + 扫描(Scan) + 分析(Analyze)
- 内部步骤名 `BuildAndAnalyzeWithSonarCloud` 不变
- 无其他引用需同步（全仓库唯一引用处）

## 注意

- 改名后 GitHub check 名称变为 `BuildScanAnalyze`（如需 required check 配置，用新名称）
- PR 扫描与 push 扫描行为不变

Closes 无