### PR TITLE
test: 补充 BaseHttpConst 与 MVSVSerializer 测试（解决 PR #2554 覆盖率质量门）

### DIFF
--- a/base/base-file/src/test/java/com/acanx/meta/base/file/mvsv/MVSVSerializerTest.java
+++ b/base/base-file/src/test/java/com/acanx/meta/base/file/mvsv/MVSVSerializerTest.java
@@ -1,0 +1,89 @@
+package com.acanx.meta.base.file.mvsv;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MVSVSerializer 序列化器测试类
+ *
+ * 覆盖 serialize 与 serializeToString 的元数据区/数据区写入逻辑。
+ *
+ * @author BeeAgent
+ * @since 2026-08-20
+ */
+class MVSVSerializerTest {
+
+    /**
+     * 构造包含中英文元数据与一行数据的 MVSVData
+     */
+    private MVSVData buildData() {
+        MVSVMetadata metadata = new MVSVMetadata();
+        metadata.setTitle("黄金分钟级行情");
+        metadata.setTitleEn("Gold Minute-level Quotes");
+        metadata.setDataProvider("xxx行情采集程序");
+        metadata.setDataProviderEn("xxx Quote Collector");
+        metadata.setField("Timestamp|Open|High");
+        metadata.setFieldEn("Timestamp|Open|High");
+        metadata.setFieldName("时间戳|开盘|最高");
+        metadata.setFieldNameEn("时间戳|开盘|最高");
+        metadata.setFieldType("timestamp|number|number");
+        metadata.setFieldTypeEn("timestamp|number|number");
+        metadata.setCount(1);
+        metadata.setRemark("备注");
+        metadata.setRemarkEn("Remark");
+
+        MVSVData data = new MVSVData();
+        data.setMetadata(metadata);
+        data.setRows(Arrays.asList(
+                Arrays.asList("2026-05-21 09:00:00", "100.0", "101.0")
+        ));
+        return data;
+    }
+
+    @Test
+    void shouldSerializeToString() {
+        MVSVSerializer serializer = new MVSVSerializer();
+        String result = serializer.serializeToString(buildData());
+
+        // 中文元数据区
+        assertTrue(result.contains("# 标题 : \"黄金分钟级行情\""));
+        assertTrue(result.contains("# 数据供应商 : xxx行情采集程序"));
+        assertTrue(result.contains("# 字段 : Timestamp|Open|High"));
+        assertTrue(result.contains("# 字段名称 : 时间戳|开盘|最高"));
+        assertTrue(result.contains("# 字段类型 : timestamp|number|number"));
+        assertTrue(result.contains("# 计数 : 1"));
+        assertTrue(result.contains("# 备注 : \"备注\""));
+
+        // 英文元数据区
+        assertTrue(result.contains("# Title : \"Gold Minute-level Quotes\""));
+        assertTrue(result.contains("# DataProvider : xxx Quote Collector"));
+        assertTrue(result.contains("# Field : Timestamp|Open|High"));
+        assertTrue(result.contains("# FieldName : 时间戳|开盘|最高"));
+        assertTrue(result.contains("# FieldType : timestamp|number|number"));
+        assertTrue(result.contains("# Count : 1"));
+        assertTrue(result.contains("# Remark : \"Remark\""));
+
+        // 数据区
+        assertTrue(result.contains("2026-05-21 09:00:00|100.0|101.0"));
+    }
+
+    @Test
+    void shouldSerializeToFile(@TempDir Path tempDir) throws IOException {
+        MVSVSerializer serializer = new MVSVSerializer();
+        Path file = tempDir.resolve("test.mvsv");
+        serializer.serialize(buildData(), file.toString());
+
+        String content = Files.readString(file);
+        assertTrue(content.contains("# 标题 : \"黄金分钟级行情\""));
+        assertTrue(content.contains("# 计数 : 1"));
+        assertTrue(content.contains("2026-05-21 09:00:00|100.0|101.0"));
+    }
+}

--- a/base/base-http/src/test/java/com/acanx/meta/base/http/c/BaseHttpConstTest.java
+++ b/base/base-http/src/test/java/com/acanx/meta/base/http/c/BaseHttpConstTest.java
@@ -1,0 +1,23 @@
+package com.acanx.meta.base.http.c;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * BaseHttpConst 常量类测试
+ *
+ * 覆盖 UTF-8 拼接常量的静态初始化逻辑。
+ *
+ * @author BeeAgent
+ * @since 2026-08-20
+ */
+class BaseHttpConstTest {
+
+    @Test
+    void shouldContainUtf8SuffixedMediaTypes() {
+        assertEquals("application/json; charset=UTF-8", BaseHttpConst.MEDIA_TYPE_APPLICATION_JSON_UTF8);
+        assertEquals("text/plain; charset=UTF-8", BaseHttpConst.MEDIA_TYPE_TEXT_PLAIN_UTF8);
+        assertEquals("text/html; charset=UTF-8", BaseHttpConst.MEDIA_TYPE_TEXT_HTML_UTF8);
+    }
+}


### PR DESCRIPTION
## 背景

PR #2554（Release V0.8.9.1，dev → main）被 SonarCloud 质量门阻塞：
**0.0% Coverage on New Code（要求 ≥ 80%）**。

经排查：**总覆盖率 30.5% 正常**，New Code 需覆盖代码仅 **17 行**（2 个文件）且全部未覆盖：
- base/base-http/.../BaseHttpConst.java（3 行 UTF-8 拼接常量）
- base/base-file/.../MVSVSerializer.java（14 行序列化逻辑）

## 变更

- 新增 `BaseHttpConstTest`：断言 UTF-8 拼接常量值，触发静态初始化覆盖 3 行
- 新增 `MVSVSerializerTest`：覆盖 serialize / serializeToString 的中英文元数据区与数据区写入（含 @TempDir 临时文件场景）

## 预期效果

PR #2554 合并后重新分析：new_uncovered_lines 17 → 0，New Code Coverage 0% → 100%，质量门通过。

Closes 无（不关闭 #2554，其 head 为 dev，本 PR 合入 dev 后 #2554 自动更新并重跑分析）