### PR TITLE
fix: 移除 MVSVSerializerTest 未使用的 import（修复 java:S1128）

### DIFF
--- a/base/base-file/src/test/java/com/acanx/meta/base/file/mvsv/MVSVSerializerTest.java
+++ b/base/base-file/src/test/java/com/acanx/meta/base/file/mvsv/MVSVSerializerTest.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 


### PR DESCRIPTION
## 背景

PR #2554（dev → main）上 SonarCloud 存在 OPEN issue：

> **java:S1128**（MINOR / CODE_SMELL）：Remove this unused import 'java.util.List'
> 位置：`MVSVSerializerTest.java` 第 10 行

该修复（删除未使用的 import）此前随 #2563 分支推送，但因 #2563 已合并而未能进入 dev，现单独递交。

## 变更

- `base/base-file/src/test/java/com/acanx/meta/base/file/mvsv/MVSVSerializerTest.java`：删除 `import java.util.List;`（代码中未显式使用 List 类型，仅 Arrays.asList 推断）

## 预期效果

合入 dev 后，PR #2554 重新分析 → java:S1128 issue 消失。