### PR TITLE
fix: 修复 CopierProcessorTest 的 S1128 与 S2699

### DIFF
--- a/meta-model/model-test/src/test/java/com/acanx/meta/model/test/annotation/copier/CopierProcessorTest.java
+++ b/meta-model/model-test/src/test/java/com/acanx/meta/model/test/annotation/copier/CopierProcessorTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -28,7 +28,7 @@ class CopierProcessorTest {
         message.setMessageContent("hello");
 
         CopierProcessor processor = new CopierProcessor();
-        processor.process(message);
+        assertDoesNotThrow(() -> processor.process(message));
     }
 
     @Test


### PR DESCRIPTION
## 背景

PR #2554 视角 SonarCloud 新增 2 个 OPEN issue（#2566 引入的 CopierProcessorTest）：

1. **java:S1128**（MINOR）：未使用的 import `assertEquals`
2. **java:S2699**（BLOCKER）：`shouldProcessMessageFlex` 缺少断言

## 变更

- 移除未使用的 `assertEquals` import
- `shouldProcessMessageFlex` 增加 `assertDoesNotThrow(() -> processor.process(message))` 断言

合并后 PR #2554 重新分析 → 2 个 issue 消失。