### PR TITLE
fix: ScheduleConst 补充 private 构造器（S1118）

### DIFF
--- a/meta-component/component-schedule/src/main/java/com/acanx/meta/component/schedule/c/ScheduleConst.java
+++ b/meta-component/component-schedule/src/main/java/com/acanx/meta/component/schedule/c/ScheduleConst.java
@@ -13,5 +13,7 @@ public class ScheduleConst {
     public static final String FIXED_RATE = "FIXED_RATE";
     public static final String CRON = "CRON";
 
-
+    private ScheduleConst() {
+        // 工具类，禁止实例化
+    }
 }


### PR DESCRIPTION
## 背景

SonarCloud 报告 **java:S1118**（MAJOR）：`ScheduleConst` 为纯常量工具类，未隐藏隐式公共构造器。

Java 编译器会为未声明构造器的类自动生成公共无参构造器；工具类不应被实例化，需显式声明 private 构造器隐藏。项目其他常量类（LLMConst、BaseHttpConst、OpenAIModel 等）均遵循此规范，ScheduleConst 为漏写。

## 变更

`ScheduleConst.java` 增加：

```java
private ScheduleConst() {
    // 工具类，禁止实例化
}
```