### PR TITLE
fix: 9 个工具类补充 private 构造器（S1118）

### DIFF
--- a/meta-component/component-schedule/src/main/java/com/acanx/meta/component/schedule/util/ExecutionTimeUtil.java
+++ b/meta-component/component-schedule/src/main/java/com/acanx/meta/component/schedule/util/ExecutionTimeUtil.java
@@ -155,4 +155,8 @@ public class ExecutionTimeUtil {
 
 
 
+
+    private ExecutionTimeUtil() {
+        // 工具类，禁止实例化
+    }
 }

--- a/meta-model/model-deepseek/src/main/java/com/acanx/meta/model/deepseek/builder/DeepSeekRiBuilder.java
+++ b/meta-model/model-deepseek/src/main/java/com/acanx/meta/model/deepseek/builder/DeepSeekRiBuilder.java
@@ -68,4 +68,8 @@ public class DeepSeekRiBuilder {
     }
 
 
+
+    private DeepSeekRiBuilder() {
+        // 工具类，禁止实例化
+    }
 }

--- a/meta-model/model-dingtalk/src/main/java/com/acanx/meta/constant/DINGTALKC.java
+++ b/meta-model/model-dingtalk/src/main/java/com/acanx/meta/constant/DINGTALKC.java
@@ -14,4 +14,8 @@ public class DINGTALKC {
     public static final String API_OTO_BATCH_SEND = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend";
 
 
+
+    private DINGTALKC() {
+        // 工具类，禁止实例化
+    }
 }

--- a/meta-model/model-dingtalk/src/main/java/com/acanx/meta/util/DingTalkSignUtil.java
+++ b/meta-model/model-dingtalk/src/main/java/com/acanx/meta/util/DingTalkSignUtil.java
@@ -26,4 +26,8 @@ public class DingTalkSignUtil {
         return URLEncoder.encode(Base64.getEncoder().encodeToString(signData), StandardCharsets.UTF_8);
     }
 
+
+    private DingTalkSignUtil() {
+        // 工具类，禁止实例化
+    }
 }

--- a/meta-model/model-test/src/main/java/com/acanx/meta/model/test/annotation/copier/copier/MessageCopier.java
+++ b/meta-model/model-test/src/main/java/com/acanx/meta/model/test/annotation/copier/copier/MessageCopier.java
@@ -33,4 +33,8 @@ public class MessageCopier {
     }
 
 
+
+    private MessageCopier() {
+        // 工具类，禁止实例化
+    }
 }

--- a/meta-model/model-test/src/main/java/com/acanx/meta/model/test/annotation/copier/copier/UserCopier.java
+++ b/meta-model/model-test/src/main/java/com/acanx/meta/model/test/annotation/copier/copier/UserCopier.java
@@ -59,4 +59,8 @@ public class UserCopier {
             }
         }
     }
+
+    private UserCopier() {
+        // 工具类，禁止实例化
+    }
 }

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
@@ -162,4 +162,8 @@ public class ArtifactService {
 
 
 
+
+    private ArtifactService() {
+        // 工具类，禁止实例化
+    }
 }

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/c/MVNC.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/c/MVNC.java
@@ -14,4 +14,8 @@ public class MVNC {
 
 
 
+
+    private MVNC() {
+        // 工具类，禁止实例化
+    }
 }

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/util/MavenArtifactUtil.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/util/MavenArtifactUtil.java
@@ -51,4 +51,8 @@ public class MavenArtifactUtil {
 
 
 
+
+    private MavenArtifactUtil() {
+        // 工具类，禁止实例化
+    }
 }


### PR DESCRIPTION
## 背景

SonarCloud java:S1118（MAJOR）：纯静态工具类/常量类未隐藏隐式公共构造器，应禁止实例化。

## 变更（9 个文件）

| 模块 | 类 |
|------|-----|
| component-schedule | ExecutionTimeUtil |
| model-deepseek | DeepSeekRiBuilder |
| model-dingtalk | DINGTALKC、DingTalkSignUtil |
| model-test | MessageCopier、UserCopier |
| sdk-maven-artifact | ArtifactService、MVNC、MavenArtifactUtil |

均为纯静态成员的工具类/常量类，补充：

```java
private Xxx() {
    // 工具类，禁止实例化
}
```