### PR TITLE
fix: ArtifactServiceTest 改静态调用（修复 dev 编译失败）

### DIFF
--- a/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/maven/artifact/ArtifactServiceTest.java
+++ b/meta-sdk/sdk-maven-artifact/src/test/java/com/acanx/meta/component/maven/artifact/ArtifactServiceTest.java
@@ -15,11 +15,9 @@ class ArtifactServiceTest {
 
     public static final String VERSION = "0.2.0.2";
 
-    public static final ArtifactService service =  new ArtifactService();
-
     @Test
     void getMavenArtifactFromMetaDataFile() {
-       MavenArtifact mavenArtifact = service.getMavenArtifactFromMetaDataFile(GROUP_ID, ARTIFACT_ID);
+       MavenArtifact mavenArtifact = ArtifactService.getMavenArtifactFromMetaDataFile(GROUP_ID, ARTIFACT_ID);
        System.out.println(mavenArtifact.toString());
        System.out.println(JSONUtil.toJSONStringPrettyFormat(mavenArtifact));
 
@@ -28,7 +26,7 @@ class ArtifactServiceTest {
 
     @Test
     void getArtifactFromLatestVersionPomFile() {
-        MavenArtifact mavenArtifact = service.getArtifactFromLatestVersionPomFile(GROUP_ID, ARTIFACT_ID, VERSION);
+        MavenArtifact mavenArtifact = ArtifactService.getArtifactFromLatestVersionPomFile(GROUP_ID, ARTIFACT_ID, VERSION);
         System.out.println(JSONUtil.toJSONStringPrettyFormat(mavenArtifact));
         assertNotNull(mavenArtifact);
     }


### PR DESCRIPTION
## 背景

PR #2574（9 个工具类补充 private 构造器）合并后，dev 编译失败：

```
ArtifactServiceTest.java:[18,51] ArtifactService() has private access in ArtifactService
```

ArtifactService 为纯静态工具类（private 构造器禁止实例化），但测试中仍 `new ArtifactService()`。

## 变更

`ArtifactServiceTest.java`：
- 删除 `public static final ArtifactService service = new ArtifactService();`
- 两个测试方法改为静态调用 `ArtifactService.getMavenArtifactFromMetaDataFile(...)` / `ArtifactService.getArtifactFromLatestVersionPomFile(...)`

合并后 dev 恢复绿色。