### PR TITLE
fix: 修复 PR 2571 SonarCloud 问题并提升覆盖率

### DIFF
--- a/base/base-file/src/test/java/com/acanx/meta/base/file/mvsv/MVSVParserTest.java
+++ b/base/base-file/src/test/java/com/acanx/meta/base/file/mvsv/MVSVParserTest.java
@@ -23,13 +23,13 @@ class MVSVParserTest {
     Path tempDir;
 
     /** 共享解析结果（由 setUp 初始化） */
-    private MVSVData data;
+    private MVSVData sharedData;
 
     @BeforeEach
     void setUp() throws IOException {
         Path testFile = tempDir.resolve("test.mvsv");
         Files.writeString(testFile, TEST_MVSV_CONTENT);
-        data = new MVSVParser().parse(testFile.toString());
+        sharedData = new MVSVParser().parse(testFile.toString());
     }
 
     // 测试数据
@@ -79,19 +79,19 @@ Timestamp|Open|High|Low|Close|Volume
     @Test
     void testParseMetadata() {
         // 验证元数据
-        assertEquals("黄金分钟级行情 - 2026-05-21", data.getMetadata().getTitle());
-        assertEquals("Gold Minute-level Quotes - 2026-05-21", data.getMetadata().getTitleEn());
-        assertEquals("xxx行情采集程序", data.getMetadata().getDataProvider());
-        assertEquals("Timestamp|Open|High|Low|Close|Volume", data.getMetadata().getField());
-        assertEquals("时间戳|开盘|最高|最低|收盘|成交量", data.getMetadata().getFieldName());
-        assertEquals("timestamp|number|number|number|number|integer", data.getMetadata().getFieldType());
-        assertEquals(3, data.getMetadata().getCount());
+        assertEquals("黄金分钟级行情 - 2026-05-21", sharedData.getMetadata().getTitle());
+        assertEquals("Gold Minute-level Quotes - 2026-05-21", sharedData.getMetadata().getTitleEn());
+        assertEquals("xxx行情采集程序", sharedData.getMetadata().getDataProvider());
+        assertEquals("Timestamp|Open|High|Low|Close|Volume", sharedData.getMetadata().getField());
+        assertEquals("时间戳|开盘|最高|最低|收盘|成交量", sharedData.getMetadata().getFieldName());
+        assertEquals("timestamp|number|number|number|number|integer", sharedData.getMetadata().getFieldType());
+        assertEquals(3, sharedData.getMetadata().getCount());
     }
 
     @Test
     void testParseFieldList() {
         // 验证字段列表
-        List<String> fieldList = data.getMetadata().getFieldList();
+        List<String> fieldList = sharedData.getMetadata().getFieldList();
         assertEquals(6, fieldList.size());
         assertEquals("Timestamp", fieldList.get(0));
         assertEquals("Open", fieldList.get(1));
@@ -104,7 +104,7 @@ Timestamp|Open|High|Low|Close|Volume
     @Test
     void testParseFieldNameList() {
         // 验证字段名称列表
-        List<String> fieldNameList = data.getMetadata().getFieldNameList();
+        List<String> fieldNameList = sharedData.getMetadata().getFieldNameList();
         assertEquals(6, fieldNameList.size());
         assertEquals("时间戳", fieldNameList.get(0));
         assertEquals("开盘", fieldNameList.get(1));
@@ -117,7 +117,7 @@ Timestamp|Open|High|Low|Close|Volume
     @Test
     void testParseFieldTypeList() {
         // 验证字段类型列表
-        List<String> fieldTypeList = data.getMetadata().getFieldTypeList();
+        List<String> fieldTypeList = sharedData.getMetadata().getFieldTypeList();
         assertEquals(6, fieldTypeList.size());
         assertEquals("timestamp", fieldTypeList.get(0));
         assertEquals("number", fieldTypeList.get(1));
@@ -130,10 +130,10 @@ Timestamp|Open|High|Low|Close|Volume
     @Test
     void testParseRows() {
         // 验证数据行
-        assertEquals(3, data.getRows().size());
+        assertEquals(3, sharedData.getRows().size());
 
         // 验证第一行数据
-        List<String> row1 = data.getRows().get(0);
+        List<String> row1 = sharedData.getRows().get(0);
         assertEquals("09:00", row1.get(0));
         assertEquals("2345.00", row1.get(1));
         assertEquals("2350.00", row1.get(2));

--- a/meta-model/model-test/src/main/java/com/acanx/meta/model/test/annotation/copier/CopierProcessor.java
+++ b/meta-model/model-test/src/main/java/com/acanx/meta/model/test/annotation/copier/CopierProcessor.java
@@ -10,6 +10,7 @@ import com.acanx.util.annotation.Copier;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.logging.Logger;
 
 /**
  * CopierProcessor
@@ -18,6 +19,8 @@ import java.time.ZoneId;
  * @since 202506
  */
 public class CopierProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(CopierProcessor.class.getName());
 
     /**
      * 单纯的注解
@@ -61,7 +64,25 @@ public class CopierProcessor {
     public void process(MessageFlex message) {
         MessageStable choice = new MessageStable();
         MessageCopier.convertMessageFlexToMessageStable(message, choice);
-        System.out.println("Copied choice: " + choice);
+        LOGGER.info("Copied choice: " + choice);
+    }
+
+    /**
+     * 用户对象拷贝演示
+     */
+    public void demoUserCopy() {
+        User user = new User(1011, "ACE", LocalDateTime.now(ZoneId.systemDefault()));
+        user.setEmail("abc@gmail.com");
+        user.setPassword("123456");
+        LOGGER.info(String.valueOf(user));
+
+        UserDTO userDTO = new UserDTO();
+        UserCopier.convertUserToUserDTO(user, userDTO);
+        LOGGER.info(String.valueOf(userDTO));
+
+        UserDTO userDTO2 = new UserDTO();
+        UserCopier.convertUserToUserDTOWithIgnorePassword(user, userDTO2);
+        LOGGER.info(String.valueOf(userDTO2));
     }
 
     /**
@@ -70,17 +91,6 @@ public class CopierProcessor {
      * @param args 命令行参数
      */
     public static void main(String[] args) {
-        User user = new User(1011, "ACE", LocalDateTime.now(ZoneId.systemDefault()));
-        user.setEmail("abc@gmail.com");
-        user.setPassword("123456");
-        System.out.println(user);
-
-        UserDTO userDTO = new UserDTO();
-        UserCopier.convertUserToUserDTO(user, userDTO);
-        System.out.println(userDTO);
-
-        UserDTO userDTO2 = new UserDTO();
-        UserCopier.convertUserToUserDTOWithIgnorePassword(user, userDTO2);
-        System.out.println(userDTO2);
+        new CopierProcessor().demoUserCopy();
     }
 }

--- a/meta-model/model-test/src/test/java/com/acanx/meta/model/test/annotation/copier/CopierProcessorTest.java
+++ b/meta-model/model-test/src/test/java/com/acanx/meta/model/test/annotation/copier/CopierProcessorTest.java
@@ -43,4 +43,10 @@ class CopierProcessorTest {
 
         assertNotNull(dto);
     }
+
+    @Test
+    void shouldDemoUserCopy() {
+        CopierProcessor processor = new CopierProcessor();
+        assertDoesNotThrow(processor::demoUserCopy);
+    }
 }


### PR DESCRIPTION
## 背景

PR #2571（Release V0.8.9.2，dev→main）的 SonarCloud 检查发现：

1. **java:S106 ×3**：`CopierProcessor` System.out 应使用 logger
2. **java:S1117 ×6**：`MVSVParserTest` 局部变量 data 遮蔽字段（#2572 拆分时引入）
3. **New Code Coverage 62.96% < 80%**：`CopierProcessor.main` 6 行未覆盖（测试不调用 main）

## 变更

- **CopierProcessor**：System.out → `java.util.logging.Logger`（项目惯例，零依赖）；main 逻辑抽取为 `demoUserCopy()` 可测方法
- **MVSVParserTest**：共享字段 `data` → `sharedData`（消除遮蔽）
- **CopierProcessorTest**：新增 `shouldDemoUserCopy` 覆盖 demoUserCopy（6 行）

## 预期

- S106 ×3 / S1117 ×6 消除
- New Code Coverage：62.96% → 接近 100%（≥ 80% 达标）