### PR TITLE
fix: CopierProcessor S2629 日志懒求值 + 覆盖率提升

### DIFF
--- a/meta-model/model-test/src/main/java/com/acanx/meta/model/test/annotation/copier/CopierProcessor.java
+++ b/meta-model/model-test/src/main/java/com/acanx/meta/model/test/annotation/copier/CopierProcessor.java
@@ -10,6 +10,7 @@ import com.acanx.util.annotation.Copier;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -64,7 +65,7 @@ public class CopierProcessor {
     public void process(MessageFlex message) {
         MessageStable choice = new MessageStable();
         MessageCopier.convertMessageFlexToMessageStable(message, choice);
-        LOGGER.info("Copied choice: " + choice);
+        LOGGER.log(Level.INFO, "Copied choice: {0}", choice);
     }
 
     /**
@@ -74,15 +75,15 @@ public class CopierProcessor {
         User user = new User(1011, "ACE", LocalDateTime.now(ZoneId.systemDefault()));
         user.setEmail("abc@gmail.com");
         user.setPassword("123456");
-        LOGGER.info(String.valueOf(user));
+        LOGGER.log(Level.INFO, "{0}", user);
 
         UserDTO userDTO = new UserDTO();
         UserCopier.convertUserToUserDTO(user, userDTO);
-        LOGGER.info(String.valueOf(userDTO));
+        LOGGER.log(Level.INFO, "{0}", userDTO);
 
         UserDTO userDTO2 = new UserDTO();
         UserCopier.convertUserToUserDTOWithIgnorePassword(user, userDTO2);
-        LOGGER.info(String.valueOf(userDTO2));
+        LOGGER.log(Level.INFO, "{0}", userDTO2);
     }
 
     /**

--- a/meta-model/model-test/src/test/java/com/acanx/meta/model/test/annotation/copier/CopierProcessorTest.java
+++ b/meta-model/model-test/src/test/java/com/acanx/meta/model/test/annotation/copier/CopierProcessorTest.java
@@ -49,4 +49,9 @@ class CopierProcessorTest {
         CopierProcessor processor = new CopierProcessor();
         assertDoesNotThrow(processor::demoUserCopy);
     }
+
+    @Test
+    void shouldRunMain() {
+        assertDoesNotThrow(() -> CopierProcessor.main(new String[0]));
+    }
 }


### PR DESCRIPTION
## 背景

PR #2571（Release V0.8.9.2）SonarCloud 检查仍有两个问题：

1. **java:S2629 ×4**：`LOGGER.info("..." + x)` 字符串拼接会无条件求值
2. **New Code Coverage 74.6% < 80%**：main 方法等 2 行未覆盖

## 变更

- **CopierProcessor**：4 处日志改为 JUL 内置格式化（懒求值）：
  ```java
  LOGGER.log(Level.INFO, "Copied choice: {0}", choice);
  LOGGER.log(Level.INFO, "{0}", user);
  ```
- **CopierProcessorTest**：新增 `shouldRunMain`（调用 main 覆盖剩余行）

## 预期

- S2629 ×4 消除
- New Code Coverage：74.6% → 接近 100%（≥ 80% 达标）