### PR TITLE
test: 补充 @Copier 空方法测试提升覆盖率（PR 2571）

### DIFF
--- a/meta-model/model-test/src/test/java/com/acanx/meta/model/test/annotation/copier/CopierProcessorTest.java
+++ b/meta-model/model-test/src/test/java/com/acanx/meta/model/test/annotation/copier/CopierProcessorTest.java
@@ -2,6 +2,7 @@ package com.acanx.meta.model.test.annotation.copier;
 
 import com.acanx.meta.model.test.annotation.copier.copier.UserCopier;
 import com.acanx.meta.model.test.annotation.model.MessageFlex;
+import com.acanx.meta.model.test.annotation.model.MessageStable;
 import com.acanx.meta.model.test.json.model.User;
 import com.acanx.meta.model.test.json.model.UserDTO;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,20 @@ class CopierProcessorTest {
     void shouldDemoUserCopy() {
         CopierProcessor processor = new CopierProcessor();
         assertDoesNotThrow(processor::demoUserCopy);
+    }
+
+
+    @Test
+    void shouldInvokeCopierAnnotatedMethods() {
+        CopierProcessor processor = new CopierProcessor();
+        MessageFlex message = new MessageFlex();
+        MessageStable stable = new MessageStable();
+        User user = new User(1011, "ACE", LocalDateTime.now());
+        UserDTO dto = new UserDTO();
+
+        assertDoesNotThrow(() -> processor.convertMessageFlexToMessageStable(message, stable));
+        assertDoesNotThrow(() -> processor.convertUserToUserDTO(user, dto));
+        assertDoesNotThrow(() -> processor.convertUserToUserDTOWithIgnorePassword(user, dto));
     }
 
     @Test


### PR DESCRIPTION
## 背景

PR #2571（Release V0.8.9.2）New Code Coverage **76.19% < 80%**。

排查定位：`CopierProcessor` 的 **3 个 @Copier 空方法**（编译期注解处理器生成实现）未被任何测试调用，各计 1 行未覆盖（文件级 22 行中 3 行未覆盖）。

## 变更

`CopierProcessorTest` 新增 `shouldInvokeCopierAnnotatedMethods`：
- 调用 `convertMessageFlexToMessageStable`
- 调用 `convertUserToUserDTO`
- 调用 `convertUserToUserDTOWithIgnorePassword`

## 预期

- 文件未覆盖行 3 → 0
- New Code Coverage 76.19% → 80%+（质量门通过）