### PR TITLE
fix: nextFire 日志输出上次执行时间参数（S1172）

### DIFF
--- a/meta-component/component-schedule/src/main/java/com/acanx/meta/component/schedule/util/ExecutionTimeUtil.java
+++ b/meta-component/component-schedule/src/main/java/com/acanx/meta/component/schedule/util/ExecutionTimeUtil.java
@@ -95,7 +95,7 @@ public class ExecutionTimeUtil {
 
         if (nextExecution.isPresent()) {
             ZonedDateTime nextFire = nextExecution.get();
-            LOGGER.log(Level.INFO, () -> "下次触发时间: " + nextFire.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
+            LOGGER.log(Level.INFO, () -> "上次执行时间: " + lastFireDateTime + ", 下次触发时间: " + nextFire.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
         } else {
             LOGGER.info("无法确定后续触发时间。");
         }


### PR DESCRIPTION
## 背景

SonarCloud 报告 `java:S1172`（未使用方法参数）：`ExecutionTimeUtil.nextFire` 的 `lastFireDateTime` 参数未被使用。

该参数保留是为保持方法签名完整（调用方传参约定），本次将参数打印输出，既消除 S1172 告警，又让日志包含更多上下文信息。

## 变更内容

**meta-component/component-schedule/.../ExecutionTimeUtil.java（1 处）**

- 修复前：
  ```java
  LOGGER.log(Level.INFO, () -> "下次触发时间: " + nextFire.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
  ```
- 修复后（日志同时输出上次执行时间与下次触发时间）：
  ```java
  LOGGER.log(Level.INFO, () -> "上次执行时间: " + lastFireDateTime + ", 下次触发时间: " + nextFire.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
  ```

## 变更性质

- 仅日志内容增强，业务逻辑零变更
- 保持 S2629 懒求值风格（Supplier lambda 内拼接，仅日志启用时才执行）

## 验证

- [x] SonarCloud 规则 `java:S1172` 问题已覆盖
- [x] 基于最新 dev（`953f039`，含已合并的 #2583）
- [ ] CI 编译验证（等待流水线结果）