### PR TITLE
fix: DingTalkSignUtil 抛出具体异常替代 Exception（S112）

### DIFF
--- a/meta-model/model-dingtalk/src/main/java/com/acanx/meta/util/DingTalkSignUtil.java
+++ b/meta-model/model-dingtalk/src/main/java/com/acanx/meta/util/DingTalkSignUtil.java
@@ -4,6 +4,8 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
 /**
@@ -16,9 +18,10 @@ public class DingTalkSignUtil {
      * @param secret      私钥
      * @param timestamp   时间戳
      * @return            签名结果
-     * @throws Exception  异常
+     * @throws NoSuchAlgorithmException 不支持的签名算法
+     * @throws InvalidKeyException      无效的密钥
      */
-    public static String generateSign(String secret, Long timestamp) throws Exception {
+    public static String generateSign(String secret, Long timestamp) throws NoSuchAlgorithmException, InvalidKeyException {
         String stringToSign = timestamp + "\n" + secret;
         Mac mac = Mac.getInstance("HmacSHA256");
         mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));


### PR DESCRIPTION
## 背景

SonarCloud 报告 `java:S112`（抛出过于通用的异常）：`DingTalkSignUtil.generateSign` 声明 `throws Exception`。

## 变更内容

**meta-model/model-dingtalk/.../util/DingTalkSignUtil.java（1 处）**

方法实际仅可能抛出两种受检异常：
- `Mac.getInstance(...)` → `NoSuchAlgorithmException`
- `mac.init(...)` → `InvalidKeyException`
- `URLEncoder.encode(String, Charset)` 为 Java 10+ Charset 重载，无受检异常

- 修复前：`public static String generateSign(String secret, Long timestamp) throws Exception`
- 修复后：`public static String generateSign(String secret, Long timestamp) throws NoSuchAlgorithmException, InvalidKeyException`
- 同步补充对应 import 与 Javadoc @throws

## 变更性质

- 异常声明收窄为具体异常，语义更清晰，符合 S112 规则
- 方法内部逻辑零变更

## 验证

- [x] SonarCloud 规则 `java:S112` 问题已覆盖
- [x] 基于最新 dev（`953f039`）
- [ ] CI 编译验证（等待流水线结果）