### PR TITLE
fix: 清理调试注释代码（java:S125）

### DIFF
--- a/meta-model/model-test/src/test/java/com/acanx/meta/model/test/DuplicateClassCheck.java
+++ b/meta-model/model-test/src/test/java/com/acanx/meta/model/test/DuplicateClassCheck.java
@@ -123,10 +123,8 @@ public class DuplicateClassCheck {
         // 移除开头的target/classes/或target/test-classes/
         if (pathStr.indexOf("target\\classes\\") >=0 ) {
             pathStr = pathStr.substring(pathStr.indexOf("target\\classes\\")+15);
-            // System.out.println(pathStr);
         } else if (pathStr.indexOf("target\\test-classes\\") >=0 ) {
             pathStr = pathStr.substring(pathStr.indexOf("target\\test-classes\\")+15);
-            // System.out.println(pathStr);
         }
 
         // 将路径分隔符替换为.，并移除.class后缀
@@ -139,14 +137,11 @@ public class DuplicateClassCheck {
      */
     private static String extractClassNameFromJavaFile(Path relativePath) {
         String pathStr = relativePath.toString();
-        // System.out.println("pathStr: " + pathStr);
         // 移除开头的src/main/java/或src/test/java/
         if (pathStr.indexOf("src\\main\\java\\") >=0 ) {
             pathStr = pathStr.substring(pathStr.indexOf("src\\main\\java\\")+14);
-            // System.out.println(pathStr);
         } else if (pathStr.indexOf("src\\test\\java\\") >=0 ) {
             pathStr = pathStr.substring(pathStr.indexOf("src\\test\\java\\")+14);
-            // System.out.println(pathStr);
         } else {
             System.out.println("=============" + pathStr);
         }

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
@@ -93,7 +93,6 @@ public class ArtifactService {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            // System.out.println("Packaging type: " + project.getPackaging());
             if (null != project.getPackaging() && !project.getPackaging().isEmpty()) {
                 packagingType = project.getPackaging();
             }


### PR DESCRIPTION
## 背景

SonarCloud 报告 `java:S125`（注释掉的代码），6 处全部是调试用的 `System.out.println` 被注释残留，清理删除。

## 变更内容（6 处，全部删除）

**meta-model/model-test/.../DuplicateClassCheck.java（5 处）**
| Issue | 行 | 内容 |
|-------|-----|------|
| #2588 | 126 | `// System.out.println(pathStr);` |
| #2589 | 129 | `// System.out.println(pathStr);` |
| #2590 | 142 | `// System.out.println(\"pathStr: \" + pathStr);` |
| #2591 | 146 | `// System.out.println(pathStr);` |
| #2592 | 149 | `// System.out.println(pathStr);` |

**meta-sdk/sdk-maven-artifact/.../ArtifactService.java（1 处）**
| Issue | 行 | 内容 |
|-------|-----|------|
| #2595 | 96 | `// System.out.println(\"Packaging type: \" + project.getPackaging());` |

## 变更性质

- 纯注释删除，零逻辑变更
- 项目另有可用的日志框架（`java.util.logging`），调试输出不应以注释形式保留

## 验证

- [x] SonarCloud 规则 `java:S125` 6 处问题全覆盖（#2588~#2592、#2595）
- [x] 基于最新 dev（`16eafc0`）
- [ ] CI 编译验证