### PR TITLE
ci: 移植 AutoMergeDependencyUpgradeSuccessPR 工作流（依赖升级 PR 自动合并）

### DIFF
--- a/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
+++ b/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
@@ -23,9 +23,13 @@ jobs:
       - name: 自动合并依赖升级 PR
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_NAME: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           set -e
-          REPO="${{ github.repository }}"
+          REPO="$REPO_NAME"
 
           # 处理单个依赖升级 PR：等待所有检查通过后自动合并（默认 squash 方式）
           process_pr() {
@@ -92,7 +96,7 @@ jobs:
             fi
           }
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             # 手动触发：遍历所有 open 的依赖升级 PR（dependabot/** 与 ci/dependency-upgrade）
             echo "🖐 手动触发模式：开始处理所有 open 的依赖升级 PR ..."
             while IFS=$'\t' read -r branch; do
@@ -104,8 +108,8 @@ jobs:
             echo "🎉 手动处理完成！"
           else
             # workflow_run 触发：处理本次 CICD run 对应的分支
-            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
-            echo "🔄 CICD 已完成（分支: ${HEAD_BRANCH}，结论: ${{ github.event.workflow_run.conclusion }}）"
+            HEAD_BRANCH="$RUN_HEAD_BRANCH"
+            echo "🔄 CI 已完成（分支: ${HEAD_BRANCH}，结论: ${RUN_CONCLUSION}）"
             case "$HEAD_BRANCH" in
               dependabot/*|ci/dependency-upgrade)
                 process_pr "$HEAD_BRANCH"

--- a/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
+++ b/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
@@ -1,0 +1,117 @@
+name: AutoMergeDependencyUpgradeSuccessPR
+
+on:
+  workflow_run:
+    # 当 MultiMavenJDKBranchCI 工作流完成时触发（依赖升级 PR 的 CI 检查即来自该工作流）
+    workflows: ["MultiMavenJDKBranchCI"]
+    types: [completed]
+  workflow_dispatch:
+    # 手动触发：处理当前所有 open 的依赖升级 PR（兜底）
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  auto-merge:
+    name: AutoMergeDependencyUpgradeSuccessPR
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: 自动合并依赖升级 PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          REPO="${{ github.repository }}"
+
+          # 处理单个依赖升级 PR：等待所有检查通过后自动合并（默认 squash 方式）
+          process_pr() {
+            local branch="$1"
+            echo ""
+            echo "=============================================="
+            echo "🔍 处理依赖升级分支: ${branch}"
+            echo "=============================================="
+
+            # 查找该分支对应的 open PR
+            local pr_number
+            pr_number=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+            if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
+              echo "ℹ️  分支 ${branch} 没有 open 的 PR，跳过。"
+              return 0
+            fi
+            echo "📋 找到依赖升级 PR: #${pr_number}"
+
+            # 获取 PR 的 head 提交 SHA（检查结果挂在该提交上）
+            local pr_head_sha
+            pr_head_sha=$(gh pr view "$pr_number" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+            echo "🔎 PR head 提交: ${pr_head_sha}"
+
+            # 轮询等待所有检查通过（最多 12 分钟，每 60 秒查询一次）
+            local i pending failed
+            pending=1
+            failed=0
+            for i in $(seq 1 12); do
+              local status_json
+              status_json=$(gh api "repos/$REPO/commits/$pr_head_sha/check-runs" --jq '.check_runs' 2>/dev/null || echo "[]")
+              pending=$(echo "$status_json" | jq '[.[] | select(.status != "completed")] | length')
+              failed=$(echo "$status_json" | jq '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
+              echo "⏳ 第 ${i}/12 次检查：pending=${pending}，failed=${failed}"
+
+              if [ "$pending" -eq 0 ] && [ "$failed" -eq 0 ]; then
+                echo "✅ PR #${pr_number} 的所有检查均已通过！"
+                break
+              fi
+              if [ "$failed" -gt 0 ]; then
+                echo "❌ PR #${pr_number} 存在失败的检查，自动合并不成功，任务退出。"
+                return 1
+              fi
+              sleep 60
+            done
+
+            # 超时仍未全部通过
+            if [ "$pending" -gt 0 ] || [ "$failed" -gt 0 ]; then
+              echo "⏰ 等待超时（12 分钟），PR #${pr_number} 尚有检查未通过，自动合并不成功，任务退出。"
+              return 1
+            fi
+
+            # 执行自动合并（默认 squash 方式）
+            echo "🔀 正在以 squash 方式自动合并 PR #${pr_number} ..."
+            if merge_output=$(gh pr merge "$pr_number" --repo "$REPO" --squash 2>&1); then
+              echo "🎉 PR #${pr_number} 已自动合并完成！"
+            else
+              echo ""
+              echo "❌ PR #${pr_number} 自动合并失败，详细信息如下："
+              echo "----------------------------------------------"
+              echo "$merge_output"
+              echo "----------------------------------------------"
+              echo "📤 自动合并不成功，任务退出。"
+              exit 1
+            fi
+          }
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # 手动触发：遍历所有 open 的依赖升级 PR（dependabot/** 与 ci/dependency-upgrade）
+            echo "🖐 手动触发模式：开始处理所有 open 的依赖升级 PR ..."
+            while IFS=$'\t' read -r branch; do
+              [ -z "$branch" ] && continue
+              process_pr "$branch"
+            done < <(gh pr list --repo "$REPO" --state open --json headRefName \
+              --jq '.[] | select(.headRefName | startswith("dependabot/") or . == "ci/dependency-upgrade") | .headRefName')
+            echo ""
+            echo "🎉 手动处理完成！"
+          else
+            # workflow_run 触发：处理本次 CICD run 对应的分支
+            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+            echo "🔄 CICD 已完成（分支: ${HEAD_BRANCH}，结论: ${{ github.event.workflow_run.conclusion }}）"
+            case "$HEAD_BRANCH" in
+              dependabot/*|ci/dependency-upgrade)
+                process_pr "$HEAD_BRANCH"
+                ;;
+              *)
+                echo "ℹ️  分支 ${HEAD_BRANCH} 不是依赖升级分支，无需处理。"
+                ;;
+            esac
+          fi


### PR DESCRIPTION
## 概述
从 [sdk-ylmf-open](https://github.com/acnxo/sdk-ylmf-open) 移植 `AutoMergeDependencyUpgradeSuccessPR.yml` 工作流，实现**依赖升级 PR 在所有检查通过后自动合并**。

## 变更内容
新增 `.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml`：

- **触发方式**：
  - `workflow_run`：监听 **MultiMavenJDKBranchCI** 完成（conclusion=success）自动触发
  - `workflow_dispatch`：手动兜底（一次处理所有 open 的依赖升级 PR）
- **处理范围**：依赖升级分支（`dependabot/**` 与 `ci/dependency-upgrade`）对应的 open PR
- **合并逻辑**：
  - 轮询等待 PR 所有 check-runs 通过（最多 12 分钟，每 60 秒查询一次）
  - 全部通过 → 自动 **squash 合并**
  - 检查失败 / 等待超时 / 合并失败 → 打印简体中文日志到控制台后退出（exit 1）
- **权限**：`contents: write`、`pull-requests: write`、`checks: read`（最小必要权限）

## 说明
- 与现有 `DependabotAutoMergeForMaven.yml`（pull_request_target 触发、仅限 os-dependencies + patch、rebase 合并）功能部分重叠但实现不同：本工作流**等待所有检查通过后合并**且覆盖所有依赖升级分支；若需统一可后续停用旧工作流
- 目标分支模式：Dependabot 升级 PR base 为 `dependa`（与现有 dependabot.yml `target-branch: dependa` 一致）

## 验证
- YAML 1.2 语法校验通过
- 逻辑与 sdk-ylmf-open 已实测版本一致（仅 workflow_run 监听目标改为 MultiMavenJDKBranchCI）

Co-authored-by: BeeAgent <BeeAgent@acanx.com>