### PR TITLE
ci: 统一 Dependabot 分支命名规则（移除 separator 短横线配置）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,8 +79,6 @@ updates:
       - "Dependabot"        
       - "RR"      
       - "From:OS-Dependencies"  
-    pull-request-branch-name:
-      separator: "-"              # 分支名使用短横线分隔
     allow:
       - dependency-type: "all"      # 允许所有依赖类型       
   - package-ecosystem: "maven"


### PR DESCRIPTION
## 背景
排查发现 Dependabot 分支名存在两种模式：
- 斜杠模式：`dependabot/maven/dependa/xxx`（默认分隔符 `/`）
- 短横线模式：`dependabot-maven-os-dependencies-dependa-xxx`（os-dependencies 条目配置了 `separator: "-"`）

短横线模式需要 AutoMerge 工作流额外适配（已通过 PR #2652 的 `dependabot-*` 匹配支持）。为从源头统一命名规则，本 PR 移除 os-dependencies 条目的 `separator: "-"` 配置。

## 变更
`.github/dependabot.yml`：移除 `/os-dependencies` 条目的：
```yaml
pull-request-branch-name:
  separator: "-"
```
恢复 Dependabot 默认 `/` 分隔符。

## 效果
- 未来所有 Dependabot 分支统一为 `dependabot/{ecosystem}/{directory}/{target-branch}/{dependency}-{version}` 斜杠模式
- 已存在的短横线分支不受影响（Dependabot 不重命名已有分支，由 AutoMerge 的 `dependabot-*` 兼容匹配兜底）

## 验证
- YAML 1.2 语法校验通过

Co-authored-by: BeeAgent <BeeAgent@acanx.com>