### PR TITLE
ci: AutoMerge 全局遍历、编号升序、取消串行化并每 6 小时兜底

### DIFF
--- a/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
+++ b/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
@@ -7,6 +7,10 @@ on:
     types: [completed]
   workflow_dispatch:
     # 手动触发：处理当前所有 open 的依赖升级 PR（兜底）
+  schedule:
+    # 定时兜底：每 3 小时执行一次，确保依赖升级 PR 不漏合并
+    # （workflow_run 并发触发时旧排队 run 会被取消，由本定时任务兜底）
+    - cron: '0 */3 * * *'
 
 concurrency:
   # 合并动作串行化：所有 AutoMerge run 共享同一队列，避免并发合并同一目标分支产生竞争
@@ -113,13 +117,19 @@ jobs:
             fi
           }
 
-          # 无论 workflow_run 还是 workflow_dispatch，均按 PR 编号升序遍历所有 open 的依赖升级 PR
+          # 无论 workflow_run / schedule / workflow_dispatch，均按 PR 编号升序遍历所有 open 的依赖升级 PR
           # （编号小的先合并，编号大的后合并；串行队列内一次推进一个）
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "🖐 手动触发模式：按 PR 编号升序处理所有 open 的依赖升级 PR ..."
-          else
-            echo "🔄 CI 已完成触发（分支: ${RUN_HEAD_BRANCH}，结论: ${RUN_CONCLUSION}），按 PR 编号升序处理 ..."
-          fi
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              echo "🖐 手动触发模式：按 PR 编号升序处理所有 open 的依赖升级 PR ..."
+              ;;
+            schedule)
+              echo "⏰ 定时兜底触发（每 3 小时）：按 PR 编号升序处理所有 open 的依赖升级 PR ..."
+              ;;
+            *)
+              echo "🔄 CI 已完成触发（分支: ${RUN_HEAD_BRANCH}，结论: ${RUN_CONCLUSION}），按 PR 编号升序处理 ..."
+              ;;
+          esac
           while IFS=$'\t' read -r number branch; do
             [ -z "$branch" ] && continue
             echo ""

--- a/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
+++ b/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
@@ -74,16 +74,16 @@ jobs:
                 break
               fi
               if [ "$failed" -gt 0 ]; then
-                echo "❌ PR #${pr_number} 存在失败的检查，自动合并不成功，任务退出。"
-                return 1
+                echo "❌ PR #${pr_number} 存在失败的检查，跳过该 PR，继续处理下一个。"
+                return 0
               fi
               sleep 60
             done
 
             # 超时仍未全部通过
             if [ "$pending" -gt 0 ] || [ "$failed" -gt 0 ]; then
-              echo "⏰ 等待超时（12 分钟），PR #${pr_number} 尚有检查未通过，自动合并不成功，任务退出。"
-              return 1
+              echo "⏰ 等待超时（12 分钟），PR #${pr_number} 尚有检查未通过，跳过该 PR，等待下次触发。"
+              return 0
             fi
 
             # 执行自动合并（默认 squash 方式）
@@ -113,27 +113,19 @@ jobs:
             fi
           }
 
+          # 无论 workflow_run 还是 workflow_dispatch，均按 PR 编号升序遍历所有 open 的依赖升级 PR
+          # （编号小的先合并，编号大的后合并；串行队列内一次推进一个）
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            # 手动触发：遍历所有 open 的依赖升级 PR（dependabot/** 与 ci/dependency-upgrade）
-            echo "🖐 手动触发模式：开始处理所有 open 的依赖升级 PR ..."
-            while IFS=$'\t' read -r branch; do
-              [ -z "$branch" ] && continue
-              process_pr "$branch"
-            done < <(gh pr list --repo "$REPO" --state open --json headRefName \
-              --jq '.[] | select(.headRefName | startswith("dependabot/") or startswith("dependabot-") or . == "ci/dependency-upgrade") | .headRefName')
-            echo ""
-            echo "🎉 手动处理完成！"
+            echo "🖐 手动触发模式：按 PR 编号升序处理所有 open 的依赖升级 PR ..."
           else
-            # workflow_run 触发：处理本次 CICD run 对应的分支
-            HEAD_BRANCH="$RUN_HEAD_BRANCH"
-            echo "🔄 CI 已完成（分支: ${HEAD_BRANCH}，结论: ${RUN_CONCLUSION}）"
-            case "$HEAD_BRANCH" in
-              # 兼容多种 Dependabot 分支命名：斜杠模式（dependabot/maven/...）与短横线模式（dependabot-maven-os-dependencies-...）
-              dependabot/*|dependabot-*|ci/dependency-upgrade)
-                process_pr "$HEAD_BRANCH"
-                ;;
-              *)
-                echo "ℹ️  分支 ${HEAD_BRANCH} 不是依赖升级分支，无需处理。"
-                ;;
-            esac
+            echo "🔄 CI 已完成触发（分支: ${RUN_HEAD_BRANCH}，结论: ${RUN_CONCLUSION}），按 PR 编号升序处理 ..."
           fi
+          while IFS=$'\t' read -r number branch; do
+            [ -z "$branch" ] && continue
+            echo ""
+            echo "📌 队列 #${number}（${branch}）"
+            process_pr "$branch"
+          done < <(gh pr list --repo "$REPO" --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("dependabot/") or startswith("dependabot-") or . == "ci/dependency-upgrade") | [.number, .headRefName] | @tsv' | sort -n)
+          echo ""
+          echo "🎉 本轮按编号顺序处理完成！"

--- a/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
+++ b/.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml
@@ -8,14 +8,9 @@ on:
   workflow_dispatch:
     # 手动触发：处理当前所有 open 的依赖升级 PR（兜底）
   schedule:
-    # 定时兜底：每 3 小时执行一次，确保依赖升级 PR 不漏合并
+    # 定时兜底：每 6 小时执行一次，确保依赖升级 PR 不漏合并
     # （workflow_run 并发触发时旧排队 run 会被取消，由本定时任务兜底）
-    - cron: '0 */3 * * *'
-
-concurrency:
-  # 合并动作串行化：所有 AutoMerge run 共享同一队列，避免并发合并同一目标分支产生竞争
-  group: automerge-dependency-prs
-  cancel-in-progress: false
+    - cron: '0 */6 * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
## 背景
1. 原 AutoMerge 在 workflow_run 模式下只处理触发它的那一个分支，合并顺序随机；存量依赖升级 PR 的 CI 早已完成，没有新的 workflow_run 事件，导致**存量 PR 永不触发自动合并**
2. concurrency 排队机制会取消旧排队 run（"higher priority waiting request"），加剧漏合并
3. 同依赖连续升级两个版本概率低，并发合并冲突概率低

## 变更
`.github/workflows/AutoMergeDependencyUpgradeSuccessPR.yml`：

### 1️⃣ 按 PR 编号升序遍历（workflow_run / schedule / workflow_dispatch 统一）
- 每次触发都按编号升序（sort -n）遍历所有 open 依赖升级 PR（dependabot/*、dependabot-*、ci/dependency-upgrade）
- 编号小的先合并、编号大的后合并
- 检查未全绿/超时：跳过该 PR（不阻塞队列）；真冲突（update-branch 失败）打印日志退出

### 2️⃣ 合并失败自动 update-branch 自愈
- 合并失败 → 自动 gh pr update-branch（以 base 分支为基准更新 head）→ CI 重跑 → 自动再次合并

### 3️⃣ 取消 concurrency 串行化
- 移除 concurrency group：每次触发完整执行，不再有排队 run 被取消
- 并发 run 幂等（已合并 PR 自动跳过），全局遍历 + 自愈 + 定时兜底保证最终一致性

### 4️⃣ 每 6 小时定时兜底（schedule: 0 */6 * * * UTC）
- 兜底 workflow_run 无新事件（存量 PR）与并发取消导致的漏合并
- 日志区分 workflow_run / schedule / workflow_dispatch 三种触发源

## 效果
- 存量 + 新增依赖升级 PR 均会被自动合并（即时 + 每 6 小时兜底）
- 编号小的先合并、编号大的后合并
- 无排队取消噪音

## 验证
- YAML 1.2 语法校验通过

Co-authored-by: BeeAgent <BeeAgent@acanx.com>