### PR TITLE
fix: 删除 EmailMessage 注释掉的字段声明（java:S125）

### DIFF
--- a/meta-model/model-mail/src/main/java/com/acanx/meta/model/email/EmailMessage.java
+++ b/meta-model/model-mail/src/main/java/com/acanx/meta/model/email/EmailMessage.java
@@ -18,8 +18,6 @@ public class EmailMessage {
 
     private List<EmailAddress> receivers;
 
-//    private String name;
-
     private String subject;
 
     private List<String> tags;


### PR DESCRIPTION
## 修复内容

删除 `EmailMessage.java` 第 21 行被注释掉的字段声明 `//    private String name;`（SonarCloud java:S125 CODE_SMELL，MAJOR）。

## 修改文件

- `meta-model/model-mail/src/main/java/com/acanx/meta/model/email/EmailMessage.java`（-2 行）

## 说明

- 该字段已无业务需要，注释残留会误导维护者；如后续需要可从版本历史找回
- 已基于最新 dev 分支（f9825b0）拉取修改

Closes #2587