### PR TITLE
fix: 注释掉的 System.out 调试输出改为 JUL 日志（java:S125）

### DIFF
--- a/meta-model/model-test/src/test/java/com/acanx/meta/model/test/DuplicateClassCheck.java
+++ b/meta-model/model-test/src/test/java/com/acanx/meta/model/test/DuplicateClassCheck.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * DuplicateClassCheck
@@ -20,6 +21,8 @@ import java.util.Map;
  * @since 20250901
  */
 public class DuplicateClassCheck {
+    private static final Logger LOG = Logger.getLogger(DuplicateClassCheck.class.getName());
+
     // 存储类名与对应文件路径的映射
     private static Map<String, List<String>> classMap = new HashMap<>();
 
@@ -123,8 +126,10 @@ public class DuplicateClassCheck {
         // 移除开头的target/classes/或target/test-classes/
         if (pathStr.indexOf("target\\classes\\") >=0 ) {
             pathStr = pathStr.substring(pathStr.indexOf("target\\classes\\")+15);
+            LOG.fine("pathStr: " + pathStr);
         } else if (pathStr.indexOf("target\\test-classes\\") >=0 ) {
             pathStr = pathStr.substring(pathStr.indexOf("target\\test-classes\\")+15);
+            LOG.fine("pathStr: " + pathStr);
         }
 
         // 将路径分隔符替换为.，并移除.class后缀
@@ -137,11 +142,14 @@ public class DuplicateClassCheck {
      */
     private static String extractClassNameFromJavaFile(Path relativePath) {
         String pathStr = relativePath.toString();
+        LOG.fine("pathStr: " + pathStr);
         // 移除开头的src/main/java/或src/test/java/
         if (pathStr.indexOf("src\\main\\java\\") >=0 ) {
             pathStr = pathStr.substring(pathStr.indexOf("src\\main\\java\\")+14);
+            LOG.fine("pathStr: " + pathStr);
         } else if (pathStr.indexOf("src\\test\\java\\") >=0 ) {
             pathStr = pathStr.substring(pathStr.indexOf("src\\test\\java\\")+14);
+            LOG.fine("pathStr: " + pathStr);
         } else {
             System.out.println("=============" + pathStr);
         }

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
@@ -93,6 +93,7 @@ public class ArtifactService {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+            LOGGER.fine("Packaging type: " + project.getPackaging());
             if (null != project.getPackaging() && !project.getPackaging().isEmpty()) {
                 packagingType = project.getPackaging();
             }


### PR DESCRIPTION
## 背景

SonarCloud 报告 `java:S125`（注释掉的代码），6 处全部是调试用的 `System.out.println` 被注释残留（此前 PR #2602 已删除，本次按需求改为 JUL 日志输出而非删除）。

## 变更内容（6 处，注释 → JUL 日志）

**meta-model/model-test/.../DuplicateClassCheck.java（5 处，新增 `java.util.logging.Logger`）**
| Issue | 原内容 | 改为 |
|-------|--------|------|
| #2588 | `// System.out.println(pathStr);`（extractClassNameFromClassFile） | `LOG.fine("pathStr: " + pathStr);` |
| #2589 | `// System.out.println(pathStr);` | `LOG.fine("pathStr: " + pathStr);` |
| #2590 | `// System.out.println("pathStr: " + pathStr);`（extractClassNameFromJavaFile） | `LOG.fine("pathStr: " + pathStr);` |
| #2591 | `// System.out.println(pathStr);` | `LOG.fine("pathStr: " + pathStr);` |
| #2592 | `// System.out.println(pathStr);` | `LOG.fine("pathStr: " + pathStr);` |

**meta-sdk/sdk-maven-artifact/.../ArtifactService.java（1 处，复用已有 LOGGER）**
| Issue | 原内容 | 改为 |
|-------|--------|------|
| #2595 | `// System.out.println("Packaging type: " + project.getPackaging());` | `LOGGER.fine("Packaging type: " + project.getPackaging());` |

## 说明

- 日志级别使用 `FINE`（调试级别）：默认不输出，按需在 logging 配置中开启，避免污染常规日志
- 基于最新 dev（`f9825b0`）

Closes #2588
Closes #2589
Closes #2590
Closes #2591
Closes #2592
Closes #2595