### PR TITLE
fix: 清理注释掉的代码与文档注释化（java:S125）

### DIFF
--- a/meta-model/model-deepseek/src/main/java/com/acanx/meta/model/deepseek/builder/DeepSeekRiBuilder.java
+++ b/meta-model/model-deepseek/src/main/java/com/acanx/meta/model/deepseek/builder/DeepSeekRiBuilder.java
@@ -61,8 +61,11 @@ public class DeepSeekRiBuilder {
         msgList.add(new Message(DeepSeekC.SYSTEM, prompt));
         msgList.add(new Message(DeepSeekC.USER, queryString));
         DeepSeekRi ri = new DeepSeekRi(DeepSeekModel.R1.getModel(), false, msgList);
-        // https://api-docs.deepseek.com/zh-cn/guides/reasoning_model#%E8%AE%BF%E9%97%AE%E6%A0%B7%E4%BE%8B
-        // ri.setTemperature(1.0D);
+        /*
+         * 参考文档（访问示例）：https://api-docs.deepseek.com/zh-cn/guides/reasoning_model#%E8%AE%BF%E9%97%AE%E6%A0%B7%E4%BE%8B
+         * Reasoner（R1）模型不支持 temperature 参数，保持默认值即可，无需显式调用
+         * ri.setTemperature(1.0D)；如需调整温度，请按上述文档中的调用方式进行设置。
+         */
         ri.setMaxTokens(32 * 1024);
         return ri;
     }

--- a/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
+++ b/meta-sdk/sdk-maven-artifact/src/main/java/com/acanx/meta/component/maven/artifact/ArtifactService.java
@@ -58,10 +58,8 @@ public class ArtifactService {
             ma.setLastUpdateDateTime(metadata.getVersioning().getLastUpdated());
             ma.setVersions(metadata.getVersioning().getVersions());
             ma.setPackaging(metadata.getVersion());
-            // ma.setIgnoreFlag(Boolean.FALSE);
             ma.setOriginDataProvider("metadata.xml");
         } else {
-            // ma.setIgnoreFlag(Boolean.TRUE);
             ma.setType(UNKNOWN);
             ma.setPackaging(UNKNOWN);
         }


### PR DESCRIPTION
## 变更内容

**meta-sdk/sdk-maven-artifact/.../ArtifactService.java（2 处，按建议删除）**
| Issue | 原内容 |
|-------|--------|
| #2593 | `// ma.setIgnoreFlag(Boolean.FALSE);`（metadata.xml 分支） |
| #2594 | `// ma.setIgnoreFlag(Boolean.TRUE);`（else 分支） |

`ignoreFlag` 字段无需赋值，直接删除；如需恢复可从版本历史找回。

**meta-model/model-deepseek/.../DeepSeekRiBuilder.java（1 处，改为文档注释）**
| Issue | 说明 |
|-------|------|
| #2596 | 原 `// 链接 + // ri.setTemperature(1.0D);` 两行改为块文档注释：保留参考文档链接（访问示例），被注释的代码改为文字描述（Reasoner/R1 模型不支持 temperature 参数，保持默认值；如需调整请按文档调用方式设置） |

## 说明

- 基于最新 dev（`e16d58e`）
- #2596 按要求保留链接与说明，仅将注释掉的代码转换为文档描述形式

Closes #2593
Closes #2594
Closes #2596